### PR TITLE
fix: Use sessionStorage for all users to support invited members

### DIFF
--- a/src/components/Dashboard/DashboardAccess.tsx
+++ b/src/components/Dashboard/DashboardAccess.tsx
@@ -18,8 +18,8 @@ export function DashboardAccess({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const [currentPath, setCurrentPath] = useState('');
 
-  // Use useCompanies hook for consistent company fetching
-  const { company, loading: isLoadingCompany, error } = useCompanies(user?.id);
+  // For invited members, always use sessionStorage company_id (undefined userId triggers sessionStorage logic)
+  const { company, loading: isLoadingCompany, error } = useCompanies(undefined);
 
   useEffect(() => {
     // Set the current path on client-side only

--- a/src/components/Dashboard/Header.tsx
+++ b/src/components/Dashboard/Header.tsx
@@ -8,8 +8,8 @@ import { useCompanies } from '../../hooks/useCompanies';
 export const DashboardHeader: React.FC = () => {
   const { user, isLoaded } = useUser();  
 
-  // Use useCompanies hook for consistent company fetching
-  const { company, loading, error } = useCompanies(user?.id);
+  // Always use sessionStorage company_id (undefined userId triggers sessionStorage logic)
+  const { company, loading, error } = useCompanies(undefined);
 
   // Show skeleton loader while loading
   if (loading) {

--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -223,8 +223,8 @@ export default function ResultsDashboard() {
   const quizzesPerPage = 5;
   const dataFetched = useRef(false);
 
-  // Use useCompanies hook for consistent company fetching
-  const { company, loading: isCompanyLoading, error: companyError } = useCompanies(user?.id);
+  // Always use sessionStorage company_id (undefined userId triggers sessionStorage logic)
+  const { company, loading: isCompanyLoading, error: companyError } = useCompanies(undefined);
   const finalCompanyId = company?.company_id || '';
 
   // Fetch quiz results

--- a/src/pages/dashboard/usage/index.tsx
+++ b/src/pages/dashboard/usage/index.tsx
@@ -5,6 +5,7 @@ import { useQuizUsage } from "@/hooks/useQuizUsage";
 import { useCompanyUsage } from "@/hooks/useCompanyUsage";
 import { useCompanies } from "@/hooks/useCompanies";
 import { DashboardHeader } from "@/components/Dashboard/Header";
+import { useUser } from "@clerk/nextjs";
 import { Loader2, Calendar, BarChart3, RefreshCw, Zap, Clock, Users, TrendingUp } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import DashboardSideBar from "@/components/SideBar/DashboardSidebar";
@@ -42,10 +43,14 @@ const LoadingCard = () => (
 );
 
 const UsagePage = () => {
+  const { user } = useUser();
   const { data: usageData, isLoading: isQuizUsageLoading, error: quizUsageError, refetch: refetchQuizUsage } = useQuizUsage();
   const { data: companyUsageData, isLoading: isCompanyUsageLoading, error: companyUsageError, refetch: refetchCompanyUsage } = useCompanyUsage();
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(new Date());
+  
+  // Always use sessionStorage company_id (undefined userId triggers sessionStorage logic)
+  const { company } = useCompanies(undefined);
   
   const currentMonth = usageData?.current_month;
   const monthlyBreakdown = usageData?.monthly_breakdown || [];


### PR DESCRIPTION
- Update all components to use useCompanies(undefined) for sessionStorage logic
- This ensures invited members always use company_id from sessionStorage
- Fixes redirect to onboarding issue for invited members
- Company name will now display correctly in header
- Analytics and Usage pages will work for invited members