### PR TITLE
fix: Implement proper fallback logic for company fetching

### DIFF
--- a/src/components/Dashboard/DashboardAccess.tsx
+++ b/src/components/Dashboard/DashboardAccess.tsx
@@ -18,10 +18,8 @@ export function DashboardAccess({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const [currentPath, setCurrentPath] = useState('');
 
-  // Check if user is company owner (has company metadata) or invited member
-  const hasCompanyMetadata = !!user?.unsafeMetadata?.companyId;
-  // Company owners: use user ID. Invited members: use sessionStorage (undefined)
-  const { company, loading: isLoadingCompany, error } = useCompanies(hasCompanyMetadata ? user?.id : undefined);
+  // Always try user ID first (for company owners), fallback to sessionStorage (for invited members)
+  const { company, loading: isLoadingCompany, error } = useCompanies(user?.id);
 
   useEffect(() => {
     // Set the current path on client-side only

--- a/src/components/Dashboard/Header.tsx
+++ b/src/components/Dashboard/Header.tsx
@@ -8,10 +8,8 @@ import { useCompanies } from '../../hooks/useCompanies';
 export const DashboardHeader: React.FC = () => {
   const { user, isLoaded } = useUser();  
 
-  // Check if user is company owner (has company metadata) or invited member
-  const hasCompanyMetadata = !!user?.unsafeMetadata?.companyId;
-  // Company owners: use user ID. Invited members: use sessionStorage (undefined)
-  const { company, loading, error } = useCompanies(hasCompanyMetadata ? user?.id : undefined);
+  // Always try user ID first, fallback to sessionStorage automatically
+  const { company, loading, error } = useCompanies(user?.id);
 
   // Show skeleton loader while loading
   if (loading) {

--- a/src/hooks/useCompanies.ts
+++ b/src/hooks/useCompanies.ts
@@ -45,53 +45,56 @@ export function useCompanies(userId: string | undefined): UseCompaniesReturn {
       setError(null);
 
       try {
+        let companyFound = false;
+        
+        // First try: fetch by user ID (for company owners)
         if (userId) {
-          // Original logic: fetch by user ID (owner)
           const response = await fetch(`/api/company/check?owner_id=${encodeURIComponent(userId)}`);
           
-          if (!response.ok) {
-            throw new Error(`Failed to fetch company information`);
+          if (response.ok) {
+            const data = await response.json();
+            
+            if (data.companies?.[0]) {
+              const companyData = data.companies[0];
+              setCompany({
+                company_id: companyData.company_id || companyData.id,
+                name: companyData.name,
+                owner_email: companyData.owner_email || ''
+              });
+              companyFound = true;
+            }
           }
-          
-          const data = await response.json();
-          
-          if (data.companies?.[0]) {
-            const companyData = data.companies[0];
-            setCompany({
-              company_id: companyData.company_id || companyData.id,
-              name: companyData.name,
-              owner_email: companyData.owner_email || ''
-            });
-          }
-        } else {
-          // New logic: fetch by company_id from sessionStorage (for invited members)
+        }
+        
+        // Second try: fetch by company_id from sessionStorage (for invited members)
+        if (!companyFound) {
           const companyId = getCompanyId();
           
-          if (!companyId) {
-            throw new Error('No user ID or company ID found');
-          }
-
-          const response = await fetch(`/api/company/${encodeURIComponent(companyId)}`);
-          
-          if (!response.ok) {
-            if (response.status === 404) {
+          if (companyId) {
+            const response = await fetch(`/api/company/${encodeURIComponent(companyId)}`);
+            
+            if (response.ok) {
+              const data = await response.json();
+              
+              setCompany({
+                company_id: data.company_id || data.id,
+                name: data.name,
+                owner_email: data.owner_email || ''
+              });
+              companyFound = true;
+            } else if (response.status === 404) {
               // Company not found, clear the stored company_id
               clearCompanyId();
-              throw new Error('Company not found. The invitation may have been revoked.');
             }
-            throw new Error(`Failed to fetch company information`);
           }
-          
-          const companyData = await response.json();
-          
-          setCompany({
-            company_id: companyData.company_id || companyData.id,
-            name: companyData.name,
-            owner_email: companyData.owner_email || ''
-          });
         }
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch company');
+        
+        // If no company found after both attempts, set company to null
+        if (!companyFound) {
+          setCompany(null);
+        }
+      } catch (error) {
+        setError(error instanceof Error ? error.message : 'Failed to fetch company information');
         setCompany(null);
       } finally {
         setLoading(false);

--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -223,10 +223,8 @@ export default function ResultsDashboard() {
   const quizzesPerPage = 5;
   const dataFetched = useRef(false);
 
-  // Check if user is company owner (has company metadata) or invited member
-  const hasCompanyMetadata = !!user?.unsafeMetadata?.companyId;
-  // Company owners: use user ID. Invited members: use sessionStorage (undefined)
-  const { company, loading: isCompanyLoading, error: companyError } = useCompanies(hasCompanyMetadata ? user?.id : undefined);
+  // Always try user ID first, fallback to sessionStorage automatically
+  const { company, loading: isCompanyLoading, error: companyError } = useCompanies(user?.id);
   const finalCompanyId = company?.company_id || '';
 
   // Fetch quiz results

--- a/src/pages/dashboard/usage/index.tsx
+++ b/src/pages/dashboard/usage/index.tsx
@@ -49,10 +49,8 @@ const UsagePage = () => {
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [lastUpdated, setLastUpdated] = useState(new Date());
   
-  // Check if user is company owner (has company metadata) or invited member
-  const hasCompanyMetadata = !!user?.unsafeMetadata?.companyId;
-  // Company owners: use user ID. Invited members: use sessionStorage (undefined)
-  const { company } = useCompanies(hasCompanyMetadata ? user?.id : undefined);
+  // Always try user ID first, fallback to sessionStorage automatically
+  const { company } = useCompanies(user?.id);
   
   const currentMonth = usageData?.current_month;
   const monthlyBreakdown = usageData?.monthly_breakdown || [];


### PR DESCRIPTION
- useCompanies hook now tries user ID first, then sessionStorage fallback
- Company owners: fetched by user ID via /api/company/check
- Invited members: fetched by sessionStorage company_id via /api/company/{id}
- Fixes issue where company owners were incorrectly treated as invited members
- Simplified all components to use useCompanies(user?.id) with automatic fallback