### PR TITLE
fix: TypeScript error in Usage page error handling

### DIFF
--- a/src/pages/dashboard/usage/index.tsx
+++ b/src/pages/dashboard/usage/index.tsx
@@ -117,7 +117,7 @@ const UsagePage = () => {
                   </div>
                   <div>
                     <p className="font-semibold text-white">Error loading usage data</p>
-                    <p className="text-sm text-gray-400">{error.message}</p>
+                    <p className="text-sm text-gray-400">{typeof error === 'string' ? error : error.message}</p>
                   </div>
                 </div>
               </CardContent>


### PR DESCRIPTION
- Fix error.message property access on string | Error type
- Add proper type checking to handle both string and Error objects