### PR TITLE
fix: Increase timeout and ensure storage priority to prevent onboardi…

### DIFF
--- a/src/app/accept_invite/page.tsx
+++ b/src/app/accept_invite/page.tsx
@@ -118,30 +118,31 @@ export default function AcceptInvitePage() {
       setIsRedirecting(true);
       setTimeout(async () => {
         try {
-          // Wait a bit to ensure company data is properly fetched
-          await new Promise(resolve => setTimeout(resolve, 800));
+          // Wait longer to ensure company data is properly fetched
+          await new Promise(resolve => setTimeout(resolve, 3000));
           
           // FIRST PRIORITY: Check sessionStorage - if exists, always redirect to dashboard
           const sessionStorageCompanyId = sessionStorage.getItem('company_id');
-          console.log('Redirect check - sessionStorageCompanyId:', sessionStorageCompanyId);
-          if (sessionStorageCompanyId) {
-            console.log('Company found in sessionStorage, redirecting to dashboard');
+          const localStorageCompanyId = localStorage.getItem('userCompanyId');
+          
+          // If either sessionStorage or localStorage has company_id, redirect to dashboard
+          if (sessionStorageCompanyId || localStorageCompanyId) {
+            console.log('Company found in storage, redirecting to dashboard');
             router.push('/dashboard');
             return;
           }
           
-          // SECONDARY: Only check metadata if sessionStorage doesn't exist
+          // SECONDARY: Only check metadata if no storage exists
           if (user) {
             await user.reload();
             
             const updatedMetadata = user.unsafeMetadata;
-            console.log('User metadata after reload:', updatedMetadata);
             
             if (updatedMetadata?.companyId) {
               console.log('Metadata confirmed, redirecting to dashboard');
               router.push('/dashboard');
             } else {
-              console.error('No company info found in sessionStorage or metadata, redirecting to onboarding');
+              console.error('No company info found in any storage, redirecting to onboarding');
               router.push('/onboarding');
             }
           } else {
@@ -150,17 +151,18 @@ export default function AcceptInvitePage() {
           }
         } catch (reloadError) {
           console.error('Error during user reload:', reloadError);
-          // Even on error, check sessionStorage first
+          // Even on error, check storage first
           const sessionStorageCompanyId = sessionStorage.getItem('company_id');
-          if (sessionStorageCompanyId) {
-            console.log('Using sessionStorage company_id despite error, redirecting to dashboard');
+          const localStorageCompanyId = localStorage.getItem('userCompanyId');
+          if (sessionStorageCompanyId || localStorageCompanyId) {
+            console.log('Using storage company_id despite error, redirecting to dashboard');
             router.push('/dashboard');
           } else {
             console.error('No company info found, redirecting to onboarding');
             router.push('/onboarding');
           }
         }
-      }, 1500); // Reduced timeout since we prioritize sessionStorage
+      }, 3000); // Increased timeout to ensure company data fetch completes
       
     } catch (error) {
       console.error('Error accepting invite:', error);

--- a/src/components/Dashboard/DashboardAccess.tsx
+++ b/src/components/Dashboard/DashboardAccess.tsx
@@ -20,13 +20,15 @@ export function DashboardAccess({ children }: { children: React.ReactNode }) {
 
   // Check if user is an invited member by checking sessionStorage first
   // Do this immediately to avoid race conditions
-  const isInvitedMember = typeof window !== 'undefined' ? !!sessionStorage.getItem('company_id') : false;
+  const sessionStorageCompanyId = typeof window !== 'undefined' ? sessionStorage.getItem('company_id') : null;
+  const isInvitedMember = !!sessionStorageCompanyId;
 
   console.log('DashboardAccess Debug:', {
+    sessionStorageCompanyId,
     isInvitedMember,
-    sessionStorageCompanyId: typeof window !== 'undefined' ? sessionStorage.getItem('company_id') : null,
     userId: user?.id,
-    isLoaded
+    isLoaded,
+    useCompaniesParam: isInvitedMember ? undefined : user?.id
   });
 
   // For invited members, use undefined to force sessionStorage logic
@@ -48,13 +50,18 @@ export function DashboardAccess({ children }: { children: React.ReactNode }) {
   }
 
   // Show loading state in the page content instead
+  // Give more time for company data to load, especially for invited members
   if (!isLoaded || isLoadingCompany) {
     return <>{children}</>;
   }
 
+  // Check both sessionStorage and localStorage for company_id
+  const localStorageCompanyId = typeof window !== 'undefined' ? localStorage.getItem('userCompanyId') : null;
+  const hasStorageCompanyId = sessionStorageCompanyId || localStorageCompanyId;
+
   // Check if user needs to create a company
-  // BUT only show onboarding if NOT an invited member (no sessionStorage company_id)
-  if (!company && !isInvitedMember) {
+  // BUT only show onboarding if NO company_id in any storage AND not an invited member
+  if (!company && !isInvitedMember && !hasStorageCompanyId) {
     return (
       <div className="min-h-screen bg-background text-white flex items-center justify-center p-4">
         <div className="w-full max-w-md">
@@ -86,9 +93,9 @@ export function DashboardAccess({ children }: { children: React.ReactNode }) {
     );
   }
 
-  // For invited members: if company data failed to load but sessionStorage exists, allow access
-  if (!company && isInvitedMember) {
-    console.log('Invited member: Company data failed to load but sessionStorage exists, allowing dashboard access');
+  // For invited members or users with storage: if company data failed to load but storage exists, allow access
+  if (!company && (isInvitedMember || hasStorageCompanyId)) {
+    console.log('User has storage company_id, allowing dashboard access despite fetch failure');
     return <>{children}</>;
   }
 


### PR DESCRIPTION
…ng redirect

- Increase timeout from 1.5s to 3s in accept_invite page to allow company data fetch
- Check both sessionStorage and localStorage for company_id before redirecting
- Only show onboarding if NO company_id exists in any storage
- Enhanced DashboardAccess to check both storage types
- Prevent redirect to onboarding when storage has company_id
- Allow dashboard access even if company fetch fails but storage exists