### PR TITLE
fix: Use sessionStorage company_id directly for invited members

### DIFF
--- a/src/components/CreateQuizCard/hooks/useCreateQuiz.ts
+++ b/src/components/CreateQuizCard/hooks/useCreateQuiz.ts
@@ -73,15 +73,30 @@ export function useCreateQuiz(): UseCreateQuizReturn {
   // auth
   const { user, isLoaded } = useUser();
 
-  // Use the same useCompanies hook as the dashboard header
-  const { company, loading: isLoadingCompany } = useCompanies(user?.id);
+  // Get company_id directly from sessionStorage (for invited members) or useCompanies (for owners)
+  const sessionStorageCompanyId = typeof window !== 'undefined' ? sessionStorage.getItem('company_id') : null;
+  const { company, loading: isLoadingCompany } = useCompanies(sessionStorageCompanyId ? undefined : user?.id);
 
-  // Convert company data to companyInfo format
-  const companyInfo: CompanyInfo | null = company ? {
+  // Use sessionStorage company_id for invited members, API data for owners
+  const companyInfo: CompanyInfo | null = sessionStorageCompanyId ? {
+    id: sessionStorageCompanyId,
+    name: localStorage.getItem('userCompanyName') || 'Company',
+    owner_email: ''
+  } : company ? {
     id: company.company_id,
     name: company.name,
     owner_email: company.owner_email
   } : null;
+
+  // Debug: Log what we're actually getting
+  console.log('useCreateQuiz - Company data:', {
+    sessionStorageCompanyId,
+    company,
+    companyInfo,
+    companyId: companyInfo?.id,
+    companyName: companyInfo?.name,
+    isInvitedMember: !!sessionStorageCompanyId
+  });
 
   // typing steps
   const steps = [

--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -26,6 +26,18 @@ export async function getCompanyId(request: NextRequest): Promise<{ company_id: 
       console.log('Found company_id in query params:', queryCompanyId);
       return { company_id: queryCompanyId };
     }
+
+    // Second, try to get company_id from request body (for invited members sending in POST body)
+    try {
+      const body = await request.json().catch(() => null);
+      if (body && body.company_id) {
+        console.log('Found company_id in request body:', body.company_id);
+        return { company_id: body.company_id };
+      }
+    } catch (e) {
+      // Ignore JSON parsing errors, continue to next method
+      console.log('Could not parse request body for company_id');
+    }
     
     // Fallback to original auth-based logic (for company owners)
     const { userId, getToken } = getAuth(request);


### PR DESCRIPTION
- For invited members: Use sessionStorage company_id directly instead of API call
- For company owners: Use useCompanies hook as before
- Prevents placeholder company_123 from being used
- Uses actual company_id from invitation acceptance response
- Fixes quiz generation for invited members