### PR TITLE
fix: TypeScript error in analytics page - use isLoading instead of lo…

### DIFF
--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -224,7 +224,7 @@ export default function ResultsDashboard() {
   const dataFetched = useRef(false);
 
   // Use the same logic as profile page
-  const { companyInfo, loading: isCompanyLoading, error: companyError } = useCompanyInfo();
+  const { companyInfo, isLoading: isCompanyLoading, error: companyError } = useCompanyInfo();
   const finalCompanyId = companyInfo?.id || '';
 
   // Fetch quiz results


### PR DESCRIPTION
…ading

- Fix Property 'loading' does not exist error
- useCompanyInfo hook returns 'isLoading' not 'loading'
- Ensures analytics page builds correctly