### PR TITLE
fix: Body already read error in quiz generation API

### DIFF
--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -163,13 +163,6 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    // Get company ID first
-    const companyResult = await getCompanyId(request);
-    if ('error' in companyResult) {
-      return companyResult.error;
-    }
-    const { company_id } = companyResult;
-
     const { userId, getToken } = getAuth(request);
     
     if (!userId) {
@@ -189,6 +182,14 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
+    
+    // Get company ID by passing the body to avoid double-reading
+    const companyResult = await getCompanyId(request, body);
+    if ('error' in companyResult) {
+      return companyResult.error;
+    }
+    const { company_id } = companyResult;
+    
     // Add company_id to the request body
     body.company_id = company_id;
     const data = await createQuiz(company_id, token, body);

--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -16,7 +16,7 @@ export interface CompanyDetails {
   updated_at: string;
 }
 
-export async function getCompanyId(request: NextRequest): Promise<{ company_id: string } | { error: Response }> {
+export async function getCompanyId(request: NextRequest, body?: any): Promise<{ company_id: string } | { error: Response }> {
   try {
     // First, try to get company_id from query parameters (for invited members)
     const { searchParams } = new URL(request.url);
@@ -28,11 +28,17 @@ export async function getCompanyId(request: NextRequest): Promise<{ company_id: 
     }
 
     // Second, try to get company_id from request body (for invited members sending in POST body)
+    if (body && body.company_id) {
+      console.log('Found company_id in request body:', body.company_id);
+      return { company_id: body.company_id };
+    }
+
+    // Try to parse body if not provided (for backward compatibility)
     try {
-      const body = await request.json().catch(() => null);
-      if (body && body.company_id) {
-        console.log('Found company_id in request body:', body.company_id);
-        return { company_id: body.company_id };
+      const parsedBody = await request.json().catch(() => null);
+      if (parsedBody && parsedBody.company_id) {
+        console.log('Found company_id in parsed request body:', parsedBody.company_id);
+        return { company_id: parsedBody.company_id };
       }
     } catch (e) {
       // Ignore JSON parsing errors, continue to next method


### PR DESCRIPTION
- Fix 'Body has already been read' error
- Pass body parameter to getCompanyId function
- Prevent double-reading of request body
- Update getCompanyId to accept optional body parameter
- Ensures quiz generation works for invited members