### PR TITLE
fix: Final TypeScript compilation error in QuizEditor

### DIFF
--- a/src/components/Quiz/QuizEditor.tsx
+++ b/src/components/Quiz/QuizEditor.tsx
@@ -218,7 +218,7 @@ export function QuizEditor() {
         });
       }
     },
-    [currentQuiz, user, company, getToken, queryClient, toast]
+    [currentQuiz, user, companyInfo, getToken, queryClient, toast]
   );
 
   // Publish handler


### PR DESCRIPTION
- Fix remaining company reference to use companyInfo in dependency array
- Resolves compilation error: Cannot find name 'company'
- Ensures all quiz operations use correct company ID from shared hook