### PR TITLE
fix: Ultimate TypeScript compilation fix in QuizEditor

### DIFF
--- a/src/components/Quiz/QuizEditor.tsx
+++ b/src/components/Quiz/QuizEditor.tsx
@@ -403,7 +403,7 @@ export function QuizEditor() {
       description: "Quiz link copied to clipboard",
       className: "border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30",
     });
-  }, [origin, quizId, company]);
+  }, [origin, quizId, companyInfo]);
 
   // FIXED: Open modal for editing with proper data population
   const handleOpenEditModal = (index: number) => {


### PR DESCRIPTION
- Fix final company reference to use companyInfo in dependency array
- Resolves last compilation error: Cannot find name 'company'
- Ensures complete consistency across all quiz operations
- All TypeScript errors should now be resolved