### PR TITLE
fix: Remove authentication requirements from check-attempt endpoint

### DIFF
--- a/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
+++ b/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
@@ -33,16 +33,10 @@ export async function GET(
       );
     }
 
-    // Get auth token from request headers
-    const authHeader = request.headers.get('authorization');
+    // No authentication required for candidate check-attempt endpoint
     const headers: Record<string, string> = {
       'accept': 'application/json',
     };
-
-    // Add auth token if present
-    if (authHeader) {
-      headers['authorization'] = authHeader;
-    }
 
     const response = await fetch(
       `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}`,


### PR DESCRIPTION
- Remove all auth token related code from candidate check-attempt endpoint
- Simplify headers to only include 'accept: application/json'
- No authentication required for candidate quiz attempt checking
- Ensures unauthenticated candidates can check their quiz attempts