### PR TITLE
fix: Add companyId parameter to check-attempt endpoint

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -179,7 +179,7 @@ export default function QuizPage({ params }: PageProps) {
     }
     try {
       const response = await fetch(
-        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}`
+        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}?companyId=${encodeURIComponent(companyId)}`
       );
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
@@ -652,7 +652,7 @@ export default function QuizPage({ params }: PageProps) {
     if (!formData?.name || !formData?.email) return false;
     try {
       const response = await fetch(
-        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}`
+        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}?companyId=${encodeURIComponent(companyId)}`
       );
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
+++ b/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
@@ -26,9 +26,13 @@ export async function GET(
     const { email: encodedEmail, quizId } = await context.params;
     const email = decodeURIComponent(encodedEmail);
 
-    if (!email || !quizId) {
+    // Get companyId from query parameters
+    const { searchParams } = new URL(request.url);
+    const companyId = searchParams.get('companyId');
+
+    if (!email || !quizId || !companyId) {
       return NextResponse.json(
-        { detail: 'Email and quiz ID are required' },
+        { detail: 'Email, quiz ID, and company ID are required' },
         { status: 400 }
       );
     }
@@ -39,7 +43,7 @@ export async function GET(
     };
 
     const response = await fetch(
-      `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}`,
+      `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}/company/${encodeURIComponent(companyId)}`,
       {
         headers,
         cache: 'no-store' // Ensure we don't get cached responses


### PR DESCRIPTION
- Add companyId as query parameter to check-attempt API calls
- Update backend service URL to include company ID in path
- Fix 404 Quiz data not found error by providing complete context
- Ensure backend can locate quiz data with company and quiz ID
- Update both check-attempt call locations in quiz attempt page