### PR TITLE
fix: Change backend URL to use companyId as query parameter

### DIFF
--- a/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
+++ b/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
@@ -43,7 +43,7 @@ export async function GET(
     };
 
     const response = await fetch(
-      `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}/company/${encodeURIComponent(companyId)}`,
+      `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}?companyId=${encodeURIComponent(companyId)}`,
       {
         headers,
         cache: 'no-store' // Ensure we don't get cached responses


### PR DESCRIPTION
- Fix Not Found error by using query parameter instead of path parameter
- Update backend service URL to use ?companyId= instead of /company/
- Match expected backend API structure for check-attempt endpoint
- Ensure backend service can properly locate quiz data