### PR TITLE
fix: Change parameter name from companyId to company_id

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -179,7 +179,7 @@ export default function QuizPage({ params }: PageProps) {
     }
     try {
       const response = await fetch(
-        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}?companyId=${encodeURIComponent(companyId)}`
+        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}?company_id=${encodeURIComponent(companyId)}`
       );
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
@@ -652,7 +652,7 @@ export default function QuizPage({ params }: PageProps) {
     if (!formData?.name || !formData?.email) return false;
     try {
       const response = await fetch(
-        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}?companyId=${encodeURIComponent(companyId)}`
+        `/api/quiz_result/check-attempt/email/${encodeURIComponent(formData.email)}/quiz/${quizId}?company_id=${encodeURIComponent(companyId)}`
       );
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));

--- a/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
+++ b/src/app/api/quiz_result/check-attempt/email/[email]/quiz/[quizId]/route.ts
@@ -26,9 +26,9 @@ export async function GET(
     const { email: encodedEmail, quizId } = await context.params;
     const email = decodeURIComponent(encodedEmail);
 
-    // Get companyId from query parameters
+    // Get company_id from query parameters
     const { searchParams } = new URL(request.url);
-    const companyId = searchParams.get('companyId');
+    const companyId = searchParams.get('company_id');
 
     if (!email || !quizId || !companyId) {
       return NextResponse.json(
@@ -43,7 +43,7 @@ export async function GET(
     };
 
     const response = await fetch(
-      `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}?companyId=${encodeURIComponent(companyId)}`,
+      `${API_BASE_URL}/check/attempt/email/${encodeURIComponent(email)}/quiz/${encodeURIComponent(quizId)}?company_id=${encodeURIComponent(companyId)}`,
       {
         headers,
         cache: 'no-store' // Ensure we don't get cached responses


### PR DESCRIPTION
- Fix Pydantic validation error by using company_id (snake_case)
- Backend expects company_id parameter, not companyId (camelCase)
- Update both API route and frontend calls to use correct parameter name
- Should resolve 'Field required' validation error from backend