### PR TITLE
fix: Add robust companyId fallbacks for unpublishing

### DIFF
--- a/src/components/Quiz/QuizHeader.tsx
+++ b/src/components/Quiz/QuizHeader.tsx
@@ -48,6 +48,14 @@ export function QuizHeader({
     try {
       setIsUnpublishing(true);
       
+      // Get companyId with multiple fallbacks
+      let companyId = company?.company_id;
+      if (!companyId && typeof window !== 'undefined') {
+        companyId = sessionStorage.getItem('company_id') || localStorage.getItem('userCompanyId') || "";
+      }
+      
+      console.log('Final companyId being sent:', companyId);
+      
       // Use PUT to update the quiz status and handle unpublishing
       const response = await fetch(`/api/quizzes`, {
         method: 'PUT',
@@ -57,7 +65,7 @@ export function QuizHeader({
         body: JSON.stringify({
           quizId,
           is_publish: false,
-          companyId: company?.company_id
+          companyId
         })
       });
 


### PR DESCRIPTION
- Add multiple fallback sources for companyId extraction
- Try company?.company_id first, then sessionStorage, then localStorage
- Add debug logging to see final companyId being sent
- Ensure companyId is always available for unpublishing
- Fix missing companyId in request payload