### PR TITLE
security: Implement comprehensive ADMIN role restrictions

### DIFF
--- a/src/pages/dashboard/my-quizzes/index.tsx
+++ b/src/pages/dashboard/my-quizzes/index.tsx
@@ -9,6 +9,8 @@ import Head from "next/head";
 import Link from "next/link";
 import { MoreVertical, Trash2 } from "lucide-react";
 import { useUserPlanContext } from "@/contexts/UserPlanContext";
+import { useUserRole } from "@/hooks/useUserRole";
+import { canPerformAction } from "@/utils/rolePermissions";
 
 import DashboardSideBar from "@/components/SideBar/DashboardSidebar";
 import { DashboardHeader } from "@/components/Dashboard/Header";
@@ -70,6 +72,9 @@ export default function MyQuizzesPage() {
   const metadataCompanyId = user?.unsafeMetadata?.companyId as string | undefined;
   const localStorageCompanyId = typeof window !== 'undefined' ? localStorage.getItem('userCompanyId') as string | null : null;
   const companyId = metadataCompanyId || localStorageCompanyId || '';
+  
+  // Now get user role after companyId is defined
+  const { userRole, loading: roleLoading } = useUserRole(companyId);
   const companyName = user?.unsafeMetadata?.companyName as string || (typeof window !== 'undefined' ? localStorage.getItem('userCompanyName') : null) || 'Company';
   
   // Determine which API endpoint to use
@@ -252,12 +257,7 @@ export default function MyQuizzesPage() {
                 ) : (
                   <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
                     {quizzes.map((q) => (
-                      <Link
-                        key={q.quiz_id}
-                        href={`/quiz/${q.quiz_id}`}
-                        rel="noopener noreferrer"
-                        className="group block"
-                      >
+                      <div key={q.quiz_id} className="group block">
                         <Card className="relative overflow-hidden cursor-pointer border-white/10 bg-gradient-to-br from-zinc-950 to-zinc-900 transition-all duration-200 ease-out group-hover:-translate-y-1 group-hover:shadow-xl group-hover:shadow-blue-500/10 group-hover:border-white/20">
                           <div className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-200 bg-[radial-gradient(600px_circle_at_var(--x,50%)_var(--y,50%),rgba(59,130,246,0.08),transparent_40%)]" />
                           <CardHeader>
@@ -275,7 +275,33 @@ export default function MyQuizzesPage() {
                                   </div>
                                 )}
                               </div>
-                              <Badge className="bg-blue-600/20 text-blue-300 border border-blue-500/30">{q.experience} yrs</Badge>
+                              <div className="flex items-center gap-2">
+                                <Badge className="bg-blue-600/20 text-blue-300 border border-blue-500/30">{q.experience} yrs</Badge>
+                                
+                                {/* Delete dropdown - Only show if user can delete quizzes */}
+                                {!roleLoading && canPerformAction(userRole, 'delete_quiz', { isQuizOwner: q.user_id === user?.id }) ? (
+                                  <DropdownMenu>
+                                    <DropdownMenuTrigger asChild>
+                                      <Button variant="ghost" className="h-8 w-8 p-0 hover:bg-white/[0.1]">
+                                        <span className="sr-only">Open menu</span>
+                                        <MoreVertical className="h-4 w-4" />
+                                      </Button>
+                                    </DropdownMenuTrigger>
+                                    <DropdownMenuContent align="end" className="bg-[#161c2a] border border-white/10">
+                                      <DropdownMenuItem
+                                        className="text-red-400 hover:text-red-300 hover:bg-red-500/[0.1] focus:text-red-300 focus:bg-red-500/[0.1]"
+                                        onClick={() => {
+                                          setQuizToDelete(q.quiz_id);
+                                          setDeleteDialogOpen(true);
+                                        }}
+                                      >
+                                        <Trash2 className="mr-2 h-4 w-4" />
+                                        Delete Quiz
+                                      </DropdownMenuItem>
+                                    </DropdownMenuContent>
+                                  </DropdownMenu>
+                                ) : null}
+                              </div>
                             </div>
                             <CardDescription className="text-white/70">
                               <span className="font-medium text-white">{q.num_questions}</span> questions
@@ -312,7 +338,7 @@ export default function MyQuizzesPage() {
                             </div>
                           </CardContent>
                         </Card>
-                      </Link>
+                      </div>
                     ))}
                   </div>
                 )}
@@ -329,6 +355,30 @@ export default function MyQuizzesPage() {
             </div>
           </div>
         </SignedOut>
+
+        {/* Delete Confirmation Dialog */}
+        <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+          <AlertDialogContent className="bg-[#161c2a] border border-white/10 text-white">
+            <AlertDialogHeader>
+              <AlertDialogTitle className="text-white">Delete Quiz</AlertDialogTitle>
+              <AlertDialogDescription className="text-white/70">
+                Are you sure you want to delete this quiz? This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel className="bg-white/10 text-white hover:bg-white/20">
+                Cancel
+              </AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => quizToDelete && handleDeleteQuiz(quizToDelete)}
+                className="bg-red-600 text-white hover:bg-red-700"
+                disabled={isDeleting}
+              >
+                {isDeleting ? 'Deleting...' : 'Delete'}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </div>
     </DashboardAccess>
   );

--- a/src/pages/dashboard/teams/index.tsx
+++ b/src/pages/dashboard/teams/index.tsx
@@ -134,7 +134,7 @@ function MemberCard({
   member: CompanyMember;
   onEditRole: (m: CompanyMember) => void;
   onDelete: (id: string, name: string) => void;
-  userRole: string | null;
+  userRole: import("@/hooks/useUserRole").UserRole | null;
   roleLoading: boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -181,19 +181,22 @@ function MemberCard({
           </div>
 
           <div className="relative flex-shrink-0" ref={menuRef}>
-            <button
-              onClick={() => setMenuOpen((o) => !o)}
-              className={`h-[28px] w-[28px] rounded-[8px] border flex flex-col items-center justify-center gap-[2.5px] transition-all duration-100 ${
-                menuOpen
-                  ? "bg-white/[0.09] border-white/[0.18]"
-                  : "border-white/[0.1] hover:bg-white/[0.07] hover:border-white/[0.18]"
-              }`}
-              aria-label="Member actions"
-            >
-              {[0, 1, 2].map((i) => (
-                <span key={i} className="block w-[3.5px] h-[3.5px] rounded-full bg-white/45" />
-              ))}
-            </button>
+            {/* Show 3 dots menu based on user permissions and member role */}
+            {!roleLoading && (
+              <button
+                onClick={() => setMenuOpen((o) => !o)}
+                className={`h-[28px] w-[28px] rounded-[8px] border flex flex-col items-center justify-center gap-[2.5px] transition-all duration-100 ${
+                  menuOpen
+                    ? "bg-white/[0.09] border-white/[0.18]"
+                    : "border-white/[0.1] hover:bg-white/[0.07] hover:border-white/[0.18]"
+                }`}
+                aria-label="Member actions"
+              >
+                {[0, 1, 2].map((i) => (
+                  <span key={i} className="block w-[3.5px] h-[3.5px] rounded-full bg-white/45" />
+                ))}
+              </button>
+            )}
 
             {menuOpen && (
               <div className="absolute top-[34px] right-0 z-50 w-[172px] rounded-[13px] border border-white/10 bg-[#161c2a] overflow-hidden shadow-[0_14px_40px_rgba(0,0,0,0.65)] animate-in fade-in slide-in-from-top-1 duration-100">
@@ -201,52 +204,66 @@ function MemberCard({
                   Actions
                 </div>
                 
-                {/* Edit Role - Only OWNER can manage roles */}
-                {!roleLoading && canPerformAction(userRole as unknown as UserRole, 'manage_roles') ? (
-                  <button
-                    onClick={() => { onEditRole(member); setMenuOpen(false); }}
-                    className="w-full flex items-center gap-[10px] px-[14px] py-[9px] text-[13px] text-white/60 hover:text-white hover:bg-white/[0.05] transition-colors text-left"
-                  >
-                    <FiEdit className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
-                    Edit role
-                  </button>
-                ) : (
-                  <DisabledButtonWithTooltip
-                    permission="manage_roles"
-                    allowedRoles={getActionAllowedRoles('manage_roles')}
-                    className="w-full"
-                    variant="outline"
-                  >
-                    <FiEdit className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
-                    Edit role
-                  </DisabledButtonWithTooltip>
-                )}
+                {/* Edit Role - OWNER can edit any role, ADMIN can edit ADMIN/MEMBER only */}
+                {(() => {
+                  const canEdit = !roleLoading && (
+                    (userRole?.role === 'OWNER') || 
+                    (userRole?.role === 'ADMIN' && member.role !== 'OWNER')
+                  );
+                  
+                  return canEdit ? (
+                    <button
+                      onClick={() => { onEditRole(member); setMenuOpen(false); }}
+                      className="w-full flex items-center gap-[10px] px-[14px] py-[9px] text-[13px] text-white/60 hover:text-white hover:bg-white/[0.05] transition-colors text-left"
+                    >
+                      <FiEdit className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
+                      Edit role
+                    </button>
+                  ) : (
+                    <DisabledButtonWithTooltip
+                      permission="manage_roles"
+                      allowedRoles={userRole?.role === 'OWNER' ? 'OWNER only' : 'Cannot edit Owner roles'}
+                      className="w-full"
+                      variant="outline"
+                    >
+                      <FiEdit className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
+                      Edit role
+                    </DisabledButtonWithTooltip>
+                  );
+                })()}
                 
                 <div className="h-px bg-white/[0.06] my-[3px]" />
                 
-                {/* Delete Member - Only OWNER can delete members */}
-                {!roleLoading && canPerformAction(userRole as unknown as UserRole, 'delete_company') ? (
-                  <button
-                    onClick={() => {
-                      onDelete(member.id, member.name ?? member.invited_email ?? "member");
-                      setMenuOpen(false);
-                    }}
-                    className="w-full flex items-center gap-[10px] px-[14px] py-[9px] text-[13px] text-red-400/80 hover:text-red-400 hover:bg-red-500/[0.1] transition-colors text-left"
-                  >
-                    <FiTrash2 className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
-                    Delete member
-                  </button>
-                ) : (
-                  <DisabledButtonWithTooltip
-                    permission="delete_company"
-                    allowedRoles={getActionAllowedRoles('delete_company')}
-                    className="w-full"
-                    variant="destructive"
-                  >
-                    <FiTrash2 className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
-                    Delete member
-                  </DisabledButtonWithTooltip>
-                )}
+                {/* Delete Member - OWNER can delete any, ADMIN can delete ADMIN/MEMBER only */}
+                {(() => {
+                  const canDelete = !roleLoading && (
+                    (userRole?.role === 'OWNER') || 
+                    (userRole?.role === 'ADMIN' && member.role !== 'OWNER')
+                  );
+                  
+                  return canDelete ? (
+                    <button
+                      onClick={() => {
+                        onDelete(member.id, member.name ?? member.invited_email ?? "member");
+                        setMenuOpen(false);
+                      }}
+                      className="w-full flex items-center gap-[10px] px-[14px] py-[9px] text-[13px] text-red-400/80 hover:text-red-400 hover:bg-red-500/[0.1] transition-colors text-left"
+                    >
+                      <FiTrash2 className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
+                      Delete member
+                    </button>
+                  ) : (
+                    <DisabledButtonWithTooltip
+                      permission="delete_company"
+                      allowedRoles={userRole?.role === 'OWNER' ? 'OWNER only' : 'Cannot delete Owner members'}
+                      className="w-full"
+                      variant="destructive"
+                    >
+                      <FiTrash2 className="w-[15px] h-[15px] flex-shrink-0 opacity-65" />
+                      Delete member
+                    </DisabledButtonWithTooltip>
+                  );
+                })()}
               </div>
             )}
           </div>
@@ -387,6 +404,16 @@ export default function TeamsPage() {
       toast({ title: "Error", description: "Please enter an email address", variant: "destructive" });
       return;
     }
+    // Validate role permissions before sending invite
+    if (userRole?.role === 'ADMIN' && inviteForm.role === 'OWNER') {
+      toast({
+        title: "Permission Denied",
+        description: "Admin users can only invite Admin and Member roles. Only Owners can invite other Owners.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsSubmittingInvite(true);
     try {
       const token = await getToken();
@@ -428,6 +455,27 @@ export default function TeamsPage() {
   const handleSaveRole = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!editingMember) return;
+
+    // Validate role permissions before updating
+    if (userRole?.role === 'ADMIN' && editingMember.role === 'OWNER') {
+      toast({
+        title: "Permission Denied",
+        description: "Admin users can only assign Admin and Member roles. Only Owners can assign Owner roles.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    // Prevent ADMIN from changing OWNER's role
+    if (userRole?.role === 'ADMIN' && editingMember.role === 'OWNER') {
+      toast({
+        title: "Permission Denied",
+        description: "Admin users cannot modify Owner roles. Only Owners can modify Owner roles.",
+        variant: "destructive",
+      });
+      return;
+    }
+
     setIsSavingRole(true);
     try {
       const token = await getToken();
@@ -461,6 +509,19 @@ export default function TeamsPage() {
 
   // ── Delete ──────────────────────────────────────────────────────────────────
   const promptDeleteMember = (id: string, name: string) => {
+    // Find the member to check their current role
+    const memberToDelete = members.find(m => m.id === id);
+    
+    // Prevent ADMIN from deleting OWNER members
+    if (userRole?.role === 'ADMIN' && memberToDelete?.role === 'OWNER') {
+      toast({
+        title: "Permission Denied",
+        description: "Admin users cannot delete Owner members. Only Owners can delete Owner members.",
+        variant: "destructive",
+      });
+      return;
+    }
+    
     setDeleteTarget({ id, name });
   };
 
@@ -610,7 +671,10 @@ export default function TeamsPage() {
                                 <SelectContent className="bg-[#1e2535] border-white/10 text-white rounded-[13px]">
                                   <SelectItem value="MEMBER">Member</SelectItem>
                                   <SelectItem value="ADMIN">Admin</SelectItem>
-                                  <SelectItem value="OWNER">Owner</SelectItem>
+                                  {/* Only OWNER can invite other OWNERS */}
+                                  {!roleLoading && userRole?.role === 'OWNER' && (
+                                    <SelectItem value="OWNER">Owner</SelectItem>
+                                  )}
                                 </SelectContent>
                               </Select>
                             </div>
@@ -682,7 +746,7 @@ export default function TeamsPage() {
                         member={member}
                         onEditRole={(m) => { setEditingMember(m); setIsEditRoleOpen(true); }}
                         onDelete={promptDeleteMember}
-                        userRole={userRole as unknown as string}
+                        userRole={userRole}
                         roleLoading={roleLoading}
                       />
                     ))}
@@ -752,7 +816,10 @@ export default function TeamsPage() {
                     <SelectContent className="bg-[#1e2535] border-white/10 text-white rounded-[13px]">
                       <SelectItem value="MEMBER">Member</SelectItem>
                       <SelectItem value="ADMIN">Admin</SelectItem>
-                      <SelectItem value="OWNER">Owner</SelectItem>
+                      {/* Only OWNER can assign OWNER role */}
+                      {!roleLoading && userRole?.role === 'OWNER' && (
+                        <SelectItem value="OWNER">Owner</SelectItem>
+                      )}
                     </SelectContent>
                   </Select>
                 </div>


### PR DESCRIPTION
- ADMIN users can only invite ADMIN and MEMBER roles (not OWNER)
- ADMIN users can only edit ADMIN and MEMBER roles (not OWNER)
- ADMIN users can delete ADMIN and MEMBER members (not OWNER)
- OWNER users have full control over all roles and operations
- Add proper TypeScript types for UserRole interface
- Fix all type comparison errors (userRole.role vs userRole)
- Add validation in invite, edit, and delete handlers
- Update UI to show/hide options based on user and member roles
- Implement hybrid approach: hide actions for unauthorized users