### PR TITLE
fix: Force role refresh when members are updated

### DIFF
--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -109,6 +109,31 @@ export function useUserRole(companyId?: string): UseUserRoleReturn {
     fetchUserRole();
   }, [user?.id, companyId]);
 
+  // Listen for storage events to force role refresh
+  useEffect(() => {
+    const handleStorageChange = () => {
+      console.log('Storage event detected, forcing role refresh...');
+      if (typeof window !== 'undefined') {
+        sessionStorage.removeItem('userRole');
+        sessionStorage.removeItem('userCompanyId');
+      }
+      // Force refetch by triggering the main effect
+      setTimeout(() => {
+        setUserRole(null);
+      }, 50);
+    };
+
+    if (typeof window !== 'undefined') {
+      window.addEventListener('storage', handleStorageChange);
+    }
+
+    return () => {
+      if (typeof window !== 'undefined') {
+        window.removeEventListener('storage', handleStorageChange);
+      }
+    };
+  }, []);
+
   return { userRole, loading, error };
 }
 

--- a/src/pages/dashboard/teams/index.tsx
+++ b/src/pages/dashboard/teams/index.tsx
@@ -378,6 +378,19 @@ export default function TeamsPage() {
       if (!response.ok) throw new Error("Failed to fetch members");
       const data = await response.json();
       setMembers(data);
+      
+      // Force role refresh to update permissions
+      console.log('Members fetched, forcing role refresh...');
+      if (typeof window !== 'undefined') {
+        sessionStorage.removeItem('userRole');
+        sessionStorage.removeItem('userCompanyId');
+      }
+      
+      // Trigger a small delay to ensure role refetch
+      setTimeout(() => {
+        window.dispatchEvent(new Event('storage'));
+      }, 100);
+      
     } catch (error) {
       console.error("Error fetching members:", error);
       toast({


### PR DESCRIPTION
- Add role refresh mechanism in fetchMembers function
- Clear sessionStorage cache when members are fetched
- Add storage event listener to useUserRole hook
- Force role refetch when storage events are triggered
- Fix issue where permissions don't update after role changes
- Ensure UI permissions update immediately after member refresh
- Add comprehensive debugging for role refresh tracking