### PR TITLE
fix: Add authorization token to useUserRole hook

### DIFF
--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useUser } from '@clerk/nextjs';
+import { useUser, useAuth } from '@clerk/nextjs';
 
 export interface UserRole {
   id: string;
@@ -24,6 +24,7 @@ interface UseUserRoleReturn {
 
 export function useUserRole(companyId?: string): UseUserRoleReturn {
   const { user } = useUser();
+  const { getToken } = useAuth();
   const [userRole, setUserRole] = useState<UserRole | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,12 +69,19 @@ export function useUserRole(companyId?: string): UseUserRoleReturn {
 
         console.log('Fetching user role:', { userId: user.id, companyId });
 
+        const token = await getToken();
+        if (!token) {
+          console.error('No auth token available');
+          throw new Error('No authentication token available');
+        }
+
         const response = await fetch(
           `/api/company-members/role?user_id=${encodeURIComponent(user.id)}&company_id=${encodeURIComponent(companyId)}`,
           {
             method: 'GET',
             headers: {
               'accept': 'application/json',
+              'Authorization': `Bearer ${token}`,
             },
           }
         );

--- a/src/pages/dashboard/teams/index.tsx
+++ b/src/pages/dashboard/teams/index.tsx
@@ -336,6 +336,7 @@ export default function TeamsPage() {
   const { toast } = useToast();
 
   // Debug logging
+  console.log('Teams page - User ID:', user?.id);
   console.log('Teams page - Company from useCompanies:', company);
   console.log('Teams page - User role:', userRole);
   console.log('Teams page - Role loading:', roleLoading);
@@ -344,6 +345,16 @@ export default function TeamsPage() {
   console.log('Teams page - Can invite members:', canPerformAction(userRole, 'invite_members'));
   console.log('Teams page - Can manage roles:', canPerformAction(userRole, 'manage_roles'));
   console.log('Teams page - Can delete company:', canPerformAction(userRole, 'delete_company'));
+  
+  // Additional debugging for role fetching
+  useEffect(() => {
+    console.log('useUserRole hook state changed:', {
+      userRole,
+      roleLoading,
+      companyId: company?.company_id,
+      userId: user?.id
+    });
+  }, [userRole, roleLoading, company?.company_id, user?.id]);
 
   // Invite dialog
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);


### PR DESCRIPTION
- Add useAuth import to get authentication token
- Include Authorization header in role API call
- Fix issue where userRole was always null on teams page
- Add token validation and error handling
- Add comprehensive debugging for role fetching
- Ensure role API calls work like other authenticated endpoints
- Fix OWNER permissions not working on teams page