### PR TITLE
fix: Critical typo in refreshMembersAndRole function

### DIFF
--- a/src/pages/dashboard/teams/index.tsx
+++ b/src/pages/dashboard/teams/index.tsx
@@ -434,7 +434,7 @@ export default function TeamsPage() {
           { headers: { Authorization: `Bearer ${token}` } }
         ),
         fetch(
-          `/api/company-members/role?user_id=companyd}&company_id=${company?.company_id}`,
+          `/api/company-members/role?user_id=${user?.id}&company_id=${company?.company_id}`,
           { headers: { Authorization: `Bearer ${token}` } }
         )
       ]);


### PR DESCRIPTION
- Fix user_id parameter from 'companyd}' to user?.id
- Resolve 404 error: 'Member with user ID companyd} not found'
- Enable proper role fetching on refresh button click
- Fix OWNER permissions not working due to malformed API call
- Ensure refresh button properly updates user permissions