### PR TITLE
Fix role management permissions and company name display issues

### DIFF
--- a/src/components/Dashboard/Header.tsx
+++ b/src/components/Dashboard/Header.tsx
@@ -27,8 +27,10 @@ export const DashboardHeader: React.FC = () => {
     <header className="px-6 py-4 border-b border-black bg-black flex items-center justify-between">
       <span> </span>
       <UserAvatarDropdown 
-        userName={(companyInfo?.name as string) || 'Company'}
+        userName={user?.firstName && user?.lastName ? `${user.firstName} ${user.lastName}` : user?.firstName || userEmail || 'User'}
         userEmail={userEmail}
+        companyName={companyInfo?.name}
+        ownerEmail={companyInfo?.owner_email}
       />
     </header>
   );

--- a/src/pages/dashboard/teams/index.tsx
+++ b/src/pages/dashboard/teams/index.tsx
@@ -205,12 +205,12 @@ function MemberCard({
                   Actions
                 </div>
                 
-                {/* Edit Role - OWNER can edit any role, ADMIN can edit ADMIN/MEMBER only */}
+                {/* Edit Role - using permission utility correctly */}
                 {(() => {
-                  const canEdit = !roleLoading && (
-                    (userRole?.role === 'OWNER') || 
-                    (userRole?.role === 'ADMIN' && member.role !== 'OWNER')
-                  );
+                  const hasManagePermission = !roleLoading && canPerformAction(userRole, 'manage_roles');
+                  const canEditTargetRole = userRole?.role === 'OWNER' || 
+                    (userRole?.role === 'ADMIN' && member.role !== 'OWNER');
+                  const canEdit = hasManagePermission && canEditTargetRole;
                   
                   return canEdit ? (
                     <button
@@ -223,7 +223,7 @@ function MemberCard({
                   ) : (
                     <DisabledButtonWithTooltip
                       permission="manage_roles"
-                      allowedRoles={userRole?.role === 'OWNER' ? 'OWNER only' : 'Cannot edit Owner roles'}
+                      allowedRoles={getActionAllowedRoles('manage_roles')}
                       className="w-full"
                       variant="outline"
                     >
@@ -235,12 +235,12 @@ function MemberCard({
                 
                 <div className="h-px bg-white/[0.06] my-[3px]" />
                 
-                {/* Delete Member - OWNER can delete any, ADMIN can delete ADMIN/MEMBER only */}
+                {/* Delete Member - using permission utility correctly */}
                 {(() => {
-                  const canDelete = !roleLoading && (
-                    (userRole?.role === 'OWNER') || 
-                    (userRole?.role === 'ADMIN' && member.role !== 'OWNER')
-                  );
+                  const hasDeletePermission = !roleLoading && canPerformAction(userRole, 'delete_company');
+                  const canDeleteTargetRole = userRole?.role === 'OWNER' || 
+                    (userRole?.role === 'ADMIN' && member.role !== 'OWNER');
+                  const canDelete = hasDeletePermission && canDeleteTargetRole;
                   
                   return canDelete ? (
                     <button
@@ -256,7 +256,7 @@ function MemberCard({
                   ) : (
                     <DisabledButtonWithTooltip
                       permission="delete_company"
-                      allowedRoles={userRole?.role === 'OWNER' ? 'OWNER only' : 'Cannot delete Owner members'}
+                      allowedRoles={getActionAllowedRoles('delete_company')}
                       className="w-full"
                       variant="destructive"
                     >
@@ -826,8 +826,8 @@ export default function TeamsPage() {
                   {/* ── FIX: right-side controls wrapper ── */}
                   <div className="flex items-center gap-3">
 
-                    {/* Invite Member */}
-                    {(!roleLoading && effectiveCanInvite) ? (
+                    {/* Invite Member - using permission utility */}
+                    {(!roleLoading && canPerformAction(userRole, 'invite_members')) ? (
                       <Dialog open={isInviteDialogOpen} onOpenChange={setIsInviteDialogOpen}>
                         <DialogTrigger asChild>
                           <Button className="bg-blue-600 hover:bg-blue-700 text-white flex items-center gap-2 px-4 py-2 rounded-xl">


### PR DESCRIPTION
- Fix Owner users unable to edit roles and delete members in Teams page
- Disable invite member button for Member role users
- Fix company name showing as 'Company' instead of actual company name in user dropdown
- Properly use canPerformAction utility for permission checks
- Separate user name and company name display in DashboardHeader