### PR TITLE
Fix authentication: Replace manual cookie extraction with Clerk getToken

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -188,11 +188,8 @@ export default function QuizPage({ params }: PageProps) {
       const entries = Object.entries(options);
       let shuffledEntries = [...entries];
 
-      console.log('Options entries before shuffle:', entries);
-
       // Special handling for code_analysis type to keep question text separate
       if (question.type === 'code_analysis') {
-        console.log('Processing code_analysis question');
         const questionKey = entries.find(([_, value]) => value === question.question)?.[0];
         if (questionKey) {
           const questionEntry = shuffledEntries.find(([key]) => key === questionKey);
@@ -210,7 +207,6 @@ export default function QuizPage({ params }: PageProps) {
         }
       } else {
         // For all other question types, just shuffle all options
-        console.log('Processing non-code_analysis question (theory, etc.)');
         for (let i = shuffledEntries.length - 1; i > 0; i--) {
           const j = Math.floor(Math.random() * (i + 1));
           [shuffledEntries[i], shuffledEntries[j]] = [shuffledEntries[j], shuffledEntries[i]];
@@ -218,11 +214,8 @@ export default function QuizPage({ params }: PageProps) {
       }
       
       const shuffledOptions = Object.fromEntries(shuffledEntries);
-      console.log('Shuffled options:', shuffledOptions);
       return { ...question, options: shuffledOptions };
     }
-    
-    console.log('No options to shuffle or invalid options format');
     return question;
   }, []);
 

--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo, useRef, useCallback } from "react";
-import { SignedIn, SignedOut, useUser } from "@clerk/nextjs";
+import { SignedIn, SignedOut, useUser, useAuth } from "@clerk/nextjs";
 import { useCachedFetch } from "@/hooks/useCachedFetch";
 import Head from "next/head";
 import * as XLSX from "xlsx";
@@ -237,6 +237,7 @@ const DisabledButtonWithTooltip = ({
 
 export default function ResultsDashboard() {
   const { user } = useUser();
+  const { getToken } = useAuth();
 
   const [selectedScores, setSelectedScores] = useState<Record<string, number | null>>({});
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -384,28 +385,19 @@ export default function ResultsDashboard() {
     try {
       setIsDeleting(true);
       
-      // Get auth token from cookies
-      const cookies = document.cookie.split(';').reduce((acc, cookie) => {
-        const [key, ...values] = cookie.trim().split('=');
-        if (key && values.length > 0) {
-          acc[key] = values.join('=');
-        }
-        return acc;
-      }, {} as Record<string, string>);
+      // Get auth token using Clerk's getToken method
+      const token = await getToken();
       
-      const authToken = cookies.__session;
-      
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-      
-      if (authToken) {
-        headers['Authorization'] = `Bearer ${authToken}`;
+      if (!token) {
+        throw new Error("No authentication token available");
       }
       
       const res = await fetch(`/api/quiz_result/delete?quiz_id=${quizId}`, {
         method: "DELETE",
-        headers,
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
       });
       if (!res.ok) {
         const err = await res.json();
@@ -435,24 +427,17 @@ export default function ResultsDashboard() {
     try {
       setIsDeleting(true);
       
-      // Get auth token from cookies
-      const cookies = document.cookie.split(';').reduce((acc, cookie) => {
-        const [key, ...values] = cookie.trim().split('=');
-        if (key && values.length > 0) {
-          acc[key] = values.join('=');
-        }
-        return acc;
-      }, {} as Record<string, string>);
+      // Get auth token using Clerk's getToken method
+      const token = await getToken();
       
-      const authToken = cookies.__session;
-      
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      };
-      
-      if (authToken) {
-        headers['Authorization'] = `Bearer ${authToken}`;
+      if (!token) {
+        throw new Error("No authentication token available");
       }
+      
+      const headers = {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${token}`,
+      };
       
       const promises = toDelete.map(({ email }) =>
         fetch(


### PR DESCRIPTION
- Import useAuth hook from Clerk
- Replace manual cookie parsing with proper getToken() method
- Fix 'Authorization token is invalid' error in analytics delete operations
- Use same authentication pattern as other components (teams page, etc.)
- Add proper error handling for missing tokens