### PR TITLE
Remove Content-Type headers from delete requests to match working pat…

### DIFF
--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -395,7 +395,6 @@ export default function ResultsDashboard() {
       const res = await fetch(`/api/quiz_result/delete?quiz_id=${quizId}`, {
         method: "DELETE",
         headers: {
-          'Content-Type': 'application/json',
           'Authorization': `Bearer ${token}`,
         },
       });
@@ -435,7 +434,6 @@ export default function ResultsDashboard() {
       }
       
       const headers = {
-        'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
       };
       


### PR DESCRIPTION
…tern

- Remove 'Content-Type: application/json' from DELETE request headers
- Match exact pattern used in teams page which works correctly
- Simplify headers to only include Authorization token