### PR TITLE
Fix authentication: Pass company_id from frontend to backend

### DIFF
--- a/src/app/api/quiz_result/delete/route.ts
+++ b/src/app/api/quiz_result/delete/route.ts
@@ -7,13 +7,14 @@ export async function DELETE(request: Request) {
   const { searchParams } = new URL(request.url);
   const quiz_id = searchParams.get('quiz_id');
   const email = searchParams.get('email');
+  const company_id = searchParams.get('company_id');
 
-  console.log('Request parameters:', { quiz_id, email });
+  console.log('Request parameters:', { quiz_id, email, company_id });
 
   try {
     // Validate required parameters
-    if (!quiz_id) {
-      const error = { message: 'quiz_id is required' };
+    if (!quiz_id || !company_id) {
+      const error = { message: 'quiz_id and company_id are required' };
       console.error('Validation error:', error);
       return NextResponse.json(error, { status: 400 });
     }
@@ -22,10 +23,10 @@ export async function DELETE(request: Request) {
     
     if (email) {
       // Delete specific user result
-      url = `${API_BASE_URL}/result/quiz/${quiz_id}/email/${encodeURIComponent(email)}`;
+      url = `${API_BASE_URL}/result/quiz/${quiz_id}/email/${encodeURIComponent(email)}?company_id=${company_id}`;
     } else {
       // Delete all results for a quiz
-      url = `${API_BASE_URL}/result/quiz/${quiz_id}`;
+      url = `${API_BASE_URL}/result/quiz/${quiz_id}?company_id=${company_id}`;
     }
 
     console.log('Making request to:', url);

--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -392,7 +392,7 @@ export default function ResultsDashboard() {
         throw new Error("No authentication token available");
       }
       
-      const res = await fetch(`/api/quiz_result/delete?quiz_id=${quizId}`, {
+      const res = await fetch(`/api/quiz_result/delete?quiz_id=${quizId}&company_id=${finalCompanyId}`, {
         method: "DELETE",
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -439,7 +439,7 @@ export default function ResultsDashboard() {
       
       const promises = toDelete.map(({ email }) =>
         fetch(
-          `/api/quiz_result/delete?quiz_id=${showDeleteUsersModal.quizId}&email=${encodeURIComponent(email)}`,
+          `/api/quiz_result/delete?quiz_id=${showDeleteUsersModal.quizId}&email=${encodeURIComponent(email)}&company_id=${finalCompanyId}`,
           { method: "DELETE", headers }
         )
       );


### PR DESCRIPTION
- Add company_id parameter to Next.js API delete route
- Update frontend to pass finalCompanyId in delete requests
- Fix mismatch between JWT sub (user_id) and DB company_id
- Backend now uses query param company_id for DB lookup instead of JWT sub
- Both delete operations (quiz and specific users) now pass correct company_id