### PR TITLE
Update topic badge placement - show only in QuizEditor, remove from c…

### DIFF
--- a/src/components/Quiz/QuestionCard.tsx
+++ b/src/components/Quiz/QuestionCard.tsx
@@ -16,9 +16,14 @@ export function QuestionCard({ question, questionNumber, onEdit, onDelete, isPub
     <Card className="bg-zinc-950 border-white/10">
       <CardHeader>
         <div className="flex items-start justify-between gap-4 flex-col sm:flex-row">
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3 flex-wrap">
             <span className="text-xl font-bold text-white">{questionNumber}.</span>
-            <Badge className="ml-2">{question.type.replace(/_/g, " ")}</Badge>
+            <Badge className="ml-2 bg-blue-500/20 text-blue-400 border-blue-500/30">
+              {question.type.replace(/_/g, " ") === 'code analysis' ? '💻 Code Analysis' : '📚 Theory'}
+            </Badge>
+            <Badge className="bg-purple-500/20 text-purple-400 border-purple-500/30">
+              🏷️ {question.topic || 'Unknown Topic'}
+            </Badge>
           </div>
           {!isPublished && (
             <div className="flex items-center gap-2 flex-wrap relative z-10 pointer-events-auto">

--- a/src/pages/quiz/attempt/[quizId].tsx
+++ b/src/pages/quiz/attempt/[quizId].tsx
@@ -1087,17 +1087,9 @@ if (typeof data.quiz === 'string') {
                 <CardContent className="p-8">
 ...
                   <div className="mb-6">
-                    <h2 className="text-2xl font-semibold text-white mb-4 leading-relaxed">
+                    <h2 className="text-2xl font-semibold text-white mb-6 leading-relaxed">
                       {quizData?.questions?.[currentQuestionIndex]?.question || 'Loading question...'}
                     </h2>
-                    <div className="flex items-center gap-2">
-                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-blue-500/20 text-blue-400 border border-blue-500/30">
-                        {quizData?.questions?.[currentQuestionIndex]?.type === 'theory' ? '📚 Theory' : '💻 Code Analysis'}
-                      </span>
-                      <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-purple-500/20 text-purple-400 border border-purple-500/30">
-                        🏷️ {quizData?.questions?.[currentQuestionIndex]?.topic || 'Unknown Topic'}
-                      </span>
-                    </div>
                   </div>
 
                   {quizData?.questions?.[currentQuestionIndex]?.code_snippet && (


### PR DESCRIPTION
…andidate page

Changes:
- Add topic and type badges to QuestionCard in QuizEditor
- Remove topic and type badges from candidate quiz attempt page
- Topic badges now only appear where questions are managed
- Clean candidate experience without visual distractions
- Topic metadata still used for accurate performance calculation