### PR TITLE
Fix remaining attempts calculation on results page

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -1720,7 +1720,7 @@ const beginQuiz = useCallback(async () => {
                               <AlertCircle className="w-5 h-5 text-blue-400 flex-shrink-0" />
                               <div>
                                 <p className="text-sm font-medium text-blue-300">
-                                  {attemptsInfo.max - attemptsInfo.current} attempt{attemptsInfo.max - attemptsInfo.current !== 1 ? 's' : ''} remaining
+                                  {attemptsInfo.max - attemptsInfo.current - 1} attempt{attemptsInfo.max - attemptsInfo.current - 1 !== 1 ? 's' : ''} remaining
                                 </p>
                                 <p className="text-xs text-gray-400 mt-0.5">
                                   Want to improve your score?
@@ -1751,7 +1751,7 @@ const beginQuiz = useCallback(async () => {
                               />
                             ))}
                             <span className="text-xs text-gray-400 ml-1">
-                              {attemptsInfo.current} used · {attemptsInfo.max - attemptsInfo.current} left
+                              {attemptsInfo.current + 1} used · {attemptsInfo.max - attemptsInfo.current - 1} left
                             </span>
                           </div>
                         </>


### PR DESCRIPTION
- Fix attempt dots: show correct used/left counts after completing attempt
- Fix remaining attempts banner: account for just-completed attempt
- Now correctly shows: '1 used · 2 left' after first attempt
- Math: used = current + 1, remaining = max - current - 1