### PR TITLE
Fix results page remaining attempts calculation

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -1721,7 +1721,7 @@ const beginQuiz = useCallback(async () => {
                               <AlertCircle className="w-5 h-5 text-blue-400 flex-shrink-0" />
                               <div>
                                 <p className="text-sm font-medium text-blue-300">
-                                  {attemptsInfo.max - attemptsInfo.current - 1} attempt{attemptsInfo.max - attemptsInfo.current - 1 !== 1 ? 's' : ''} remaining
+                                  {attemptsInfo.max - attemptsInfo.current} attempt{attemptsInfo.max - attemptsInfo.current !== 1 ? 's' : ''} remaining
                                 </p>
                                 <p className="text-xs text-gray-400 mt-0.5">
                                   Want to improve your score?


### PR DESCRIPTION
- Fix results page banner to show correct remaining attempts after completion
- After 1st attempt: shows '2 attempts remaining' (not 1)
- Logic: remaining = max - current (attempts still available)
- AttemptsModal logic unchanged: shows attempts left AFTER current one
- Both pages now show accurate attempt counts