### PR TITLE
fix: Resolve 'Body has already been read' error in tech stack route

### DIFF
--- a/src/app/api/quiz/file/route.ts
+++ b/src/app/api/quiz/file/route.ts
@@ -40,15 +40,15 @@ export async function POST(req: NextRequest) {
     const formData = await req.formData();
     const companyIdFromForm = formData.get('company_id') as string;
     
-    // Create a body object for getCompanyId function
-    const bodyForCompanyId = { company_id: companyIdFromForm };
-    
-    // Get company ID using the same function as tech stack route
-    const companyResult = await getCompanyId(req, bodyForCompanyId);
-    if ('error' in companyResult) {
-      return companyResult.error;
+    // Validate company ID directly since we already have it from form data
+    if (!companyIdFromForm) {
+      return NextResponse.json({
+        error: 'Company ID is required',
+        details: 'Company ID must be provided in form data'
+      }, { status: 400 });
     }
-    const { company_id: companyId } = companyResult;
+    
+    const companyId = companyIdFromForm;
 
     
     // Extract required fields

--- a/src/app/api/quizzes/route.ts
+++ b/src/app/api/quizzes/route.ts
@@ -183,14 +183,19 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
     
-    // Get company ID by passing the body to avoid double-reading
-    const companyResult = await getCompanyId(request, body);
-    if ('error' in companyResult) {
-      return companyResult.error;
-    }
-    const { company_id } = companyResult;
+    // Check if company_id is already in the body (from frontend)
+    let company_id = body.company_id;
     
-    // Add company_id to the request body
+    // If not in body, try to get it from query params or fallback to getCompanyId
+    if (!company_id) {
+      const companyResult = await getCompanyId(request);
+      if ('error' in companyResult) {
+        return companyResult.error;
+      }
+      company_id = companyResult.company_id;
+    }
+    
+    // Ensure company_id is in the body for createQuiz function
     body.company_id = company_id;
     const data = await createQuiz(company_id, token, body);
     return NextResponse.json(data, { status: 201 });


### PR DESCRIPTION
- Fix company ID handling to avoid double-reading request body
- Check if company_id exists in body before calling getCompanyId
- Fallback to getCompanyId only when company_id not provided
- Ensure consistent body handling across both quiz routes