### PR TITLE
fix: resolve company_id for members in quiz expiration check

### DIFF
--- a/src/components/QuizExpirationChecker.tsx
+++ b/src/components/QuizExpirationChecker.tsx
@@ -11,12 +11,14 @@ interface ExpirationCheckResult {
   errors?: string[];
 }
 
-export function QuizExpirationChecker({ 
-  autoCheck = false, 
-  checkInterval = 5 * 60 * 1000 // 5 minutes
-}: { 
-  autoCheck?: boolean; 
-  checkInterval?: number; 
+export function QuizExpirationChecker({
+  autoCheck = false,
+  checkInterval = 5 * 60 * 1000, // 5 minutes
+  companyId
+}: {
+  autoCheck?: boolean;
+  checkInterval?: number;
+  companyId?: string;
 }) {
   const { user } = useUser();
   const queryClient = useQueryClient();
@@ -25,10 +27,18 @@ export function QuizExpirationChecker({
 
   const checkExpiration = async () => {
     if (!user) return;
-    
+
     setIsChecking(true);
     try {
-      const response = await fetch('/api/quiz/check-expiration', {
+      // Pass the already-resolved company_id (metadata/localStorage aware,
+      // works for owners and members alike) so the server doesn't have to
+      // fall back to the owner-only /companies?owner_id= lookup, which
+      // fails for non-owner members.
+      const url = companyId
+        ? `/api/quiz/check-expiration?company_id=${encodeURIComponent(companyId)}`
+        : '/api/quiz/check-expiration';
+
+      const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -82,7 +92,7 @@ export function QuizExpirationChecker({
     const interval = setInterval(checkExpiration, checkInterval);
 
     return () => clearInterval(interval);
-  }, [autoCheck, checkInterval, user]);
+  }, [autoCheck, checkInterval, user, companyId]);
 
   // Manual trigger button
   const ManualCheckButton = () => (
@@ -104,9 +114,10 @@ export function QuizExpirationChecker({
 }
 
 // Hook for easier usage
-export function useQuizExpirationChecker(options?: { 
-  autoCheck?: boolean; 
-  checkInterval?: number; 
+export function useQuizExpirationChecker(options?: {
+  autoCheck?: boolean;
+  checkInterval?: number;
+  companyId?: string;
 }) {
   return QuizExpirationChecker(options || {});
 }

--- a/src/pages/dashboard/my-quizzes/index.tsx
+++ b/src/pages/dashboard/my-quizzes/index.tsx
@@ -79,9 +79,10 @@ export default function MyQuizzesPage() {
   const companyName = user?.unsafeMetadata?.companyName as string || (typeof window !== 'undefined' ? localStorage.getItem('userCompanyName') : null) || 'Company';
   
   // Set up automatic expiration checking (every 5 minutes)
-  useQuizExpirationChecker({ 
-    autoCheck: true, 
-    checkInterval: 5 * 60 * 1000 
+  useQuizExpirationChecker({
+    autoCheck: true,
+    checkInterval: 5 * 60 * 1000,
+    companyId: companyId || undefined
   });
   
   // Determine which API endpoint to use


### PR DESCRIPTION
/api/quiz/check-expiration fell back to the owner-only /companies?owner_id= lookup whenever no company_id was supplied, causing "Expiration Check Failed" for member accounts on the My Quizzes page. Pass the already-resolved company_id (metadata/ localStorage aware) from the My Quizzes page into
useQuizExpirationChecker so the server uses the member's actual company instead of trying to look them up as an owner.