### PR TITLE
feat: multi-file upload, theory-only non-technical UX, quiz-type tag,…

### DIFF
--- a/src/app/api/quiz/file/route.ts
+++ b/src/app/api/quiz/file/route.ts
@@ -56,9 +56,16 @@ export async function POST(req: NextRequest) {
 
     // Validate required fields
     if (!files || files.length === 0) {
-      return NextResponse.json({ 
+      return NextResponse.json({
         error: 'Bad Request',
         details: 'At least one file is required'
+      }, { status: 400 });
+    }
+
+    if (files.length > 3) {
+      return NextResponse.json({
+        error: 'Bad Request',
+        details: 'A maximum of 3 files is allowed'
       }, { status: 400 });
     }
 
@@ -86,10 +93,10 @@ export async function POST(req: NextRequest) {
 
     const BACKEND_URL_WITH_PARAMS = `${BACKEND_URL}?${params.toString()}`;
 
-    // ✅ FIX: Send all files in FormData
+    // Send all files in FormData — backend accepts a list under the 'files' field
     const backendFormData = new FormData();
-    files.forEach((file, index) => {
-      backendFormData.append('file', file);  // Backend expects 'file' (singular)
+    files.forEach((file) => {
+      backendFormData.append('files', file);
     });
 
     // Debug: Log FormData contents (should contain all files now)

--- a/src/app/api/quiz_result/delete/route.ts
+++ b/src/app/api/quiz_result/delete/route.ts
@@ -8,21 +8,25 @@ export async function DELETE(request: Request) {
   const quiz_id = searchParams.get('quiz_id');
   const email = searchParams.get('email');
   const company_id = searchParams.get('company_id');
+  const attempt_id = searchParams.get('attempt_id');
 
-  console.log('Request parameters:', { quiz_id, email, company_id });
+  console.log('Request parameters:', { quiz_id, email, company_id, attempt_id });
 
   try {
     // Validate required parameters
-    if (!quiz_id || !company_id) {
-      const error = { message: 'quiz_id and company_id are required' };
+    if (!company_id || (!attempt_id && !quiz_id)) {
+      const error = { message: 'company_id and either attempt_id or quiz_id are required' };
       console.error('Validation error:', error);
       return NextResponse.json(error, { status: 400 });
     }
 
     let url: string;
-    
-    if (email) {
-      // Delete specific user result
+
+    if (attempt_id) {
+      // Delete one specific attempt row — leaves the candidate's other attempts intact
+      url = `${API_BASE_URL}/result/attempt/${attempt_id}?company_id=${company_id}`;
+    } else if (email) {
+      // Delete specific user result (all attempts for this candidate on this quiz)
       url = `${API_BASE_URL}/result/quiz/${quiz_id}/email/${encodeURIComponent(email)}?company_id=${company_id}`;
     } else {
       // Delete all results for a quiz

--- a/src/components/CreateQuizCard/hooks/useCreateQuizV2.ts
+++ b/src/components/CreateQuizCard/hooks/useCreateQuizV2.ts
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState, useCallback, ReactNode } from "react";
-import { Cpu, Code, Sparkles, CheckCircle } from "lucide-react";
+import { Cpu, Code, Sparkles, CheckCircle, BookOpen } from "lucide-react";
 import { useUser } from "@clerk/nextjs";
 import { useQuizGeneration } from "@/contexts/QuizGenerationContext";
 import { useCompanyInfo } from "@/hooks/useCompanyInfo";
@@ -70,14 +70,27 @@ export function useCreateQuizV2(): UseCreateQuizReturn {
   // Use the same logic as profile page
   const { companyInfo, isLoading: isLoadingCompany } = useCompanyInfo();
 
-  // typing steps
-  const steps = [
+  // typing steps — text depends on which quiz type is currently being generated,
+  // set at the start of handleGenerate. Non-technical quizzes have no tech stack/role
+  // matching or code-analysis questions, so that language must not appear for them.
+  const [activeQuizType, setActiveQuizType] = useState<'technical' | 'non_technical'>('technical');
+
+  const TECHNICAL_STEPS = [
     " Parsing and understanding the topic semantics...",
     " Balancing code-analysis and theoretical coverage...",
     " Generating question templates & code scaffolds...",
     " Validating difficulty and finalizing the quiz...",
   ];
-  const stepIcons = [Cpu, Code, Sparkles, CheckCircle];
+  const NON_TECHNICAL_STEPS = [
+    " Reading and understanding your uploaded document...",
+    " Identifying key concepts and professional topics...",
+    " Generating theory-based questions from those concepts...",
+    " Validating difficulty and finalizing the quiz...",
+  ];
+  const steps = activeQuizType === 'non_technical' ? NON_TECHNICAL_STEPS : TECHNICAL_STEPS;
+  const stepIcons = activeQuizType === 'non_technical'
+    ? [Cpu, BookOpen, Sparkles, CheckCircle]
+    : [Cpu, Code, Sparkles, CheckCircle];
 
   const [stepIndex, setStepIndex] = useState(0);
   const [typedText, setTypedText] = useState("");
@@ -126,6 +139,8 @@ export function useCreateQuizV2(): UseCreateQuizReturn {
     quizType: 'technical' | 'non_technical' = 'technical'
   ): Promise<void> => {
     if (isReasoning || isFetching) return;
+
+    setActiveQuizType(quizType);
 
     const numQuestions = Number.isFinite(count) ? Math.max(1, count) : 1;
 
@@ -221,7 +236,7 @@ export function useCreateQuizV2(): UseCreateQuizReturn {
       if (uploadedFiles && uploadedFiles.length > 0) {
         // Build FormData - backend will handle file reading
         const formData = new FormData();
-        formData.append('files', uploadedFiles[0].file);
+        uploadedFiles.forEach((uf) => formData.append('files', uf.file));
         formData.append('role', role);
         formData.append('experience', experienceToApi(experience));
         formData.append('num_questions', numQuestions.toString());
@@ -238,8 +253,7 @@ export function useCreateQuizV2(): UseCreateQuizReturn {
           numQuestions,
           theoryQuestionsPercentage: 100 - codePct,
           codeAnalysisQuestionsPercentage: codePct,
-          fileName: uploadedFiles[0].name,
-          fileSize: uploadedFiles[0].size,
+          files: uploadedFiles.map(uf => ({ name: uf.name, size: uf.size })),
         });
         
         response = await fetch('/api/quiz/file', {

--- a/src/components/CreateQuizCard/index.tsx
+++ b/src/components/CreateQuizCard/index.tsx
@@ -1,5 +1,5 @@
 import { Card, CardContent } from "@/components/ui/card";
-import { Zap, AlertTriangle } from "lucide-react";
+import { Zap, AlertTriangle, BookOpen } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
@@ -237,12 +237,13 @@ export default function CreateQuizCard({
     setError("");
 
     if (isNonTechnicalRole) {
-      // Non-technical roles are always document-upload based
+      // Non-technical roles are always document-upload based and 100% theory —
+      // there is no split slider for this mode, so force 0% regardless of stale slider state.
       if (!uploadedFiles || uploadedFiles.length === 0) {
         setError("Please upload a document to generate quiz questions");
         return;
       }
-      _handleGenerate([], codePct, role, uploadedFiles, 'non_technical');
+      _handleGenerate([], 0, role, uploadedFiles, 'non_technical');
       return;
     }
 
@@ -380,12 +381,16 @@ export default function CreateQuizCard({
                 : "opacity-0 -translate-y-4 pointer-events-none absolute"
             )}>
               <div className="space-y-2">
-                {isNonTechnicalRole && (
-                  <p className="text-sm text-muted-foreground">
-                    Document upload is required for this role — the quiz will be generated from its content.
-                  </p>
-                )}
-                <FileUpload value={uploadedFiles} onChange={setUploadedFiles} maxFiles={1} />
+                <FileUpload
+                  value={uploadedFiles}
+                  onChange={setUploadedFiles}
+                  maxFiles={3}
+                  description={
+                    isNonTechnicalRole
+                      ? "Document upload is required for this role. Upload up to 3 files (e.g. policy docs, guidelines, training material) — the quiz will be generated entirely from their content."
+                      : undefined
+                  }
+                />
               </div>
             </div>
           </div>
@@ -400,14 +405,25 @@ export default function CreateQuizCard({
           />
 
           <div className="space-y-2 pt-4">
-            <div className="flex items-center justify-between">
-              <Label className="text-foreground">Question Distribution</Label>
-            </div>
-            <CodeTheorySlider
-              codePercentage={codePercentage}
-              onCodePercentageChange={setCodePercentage}
-              mode={roleType}
-            />
+            {isNonTechnicalRole ? (
+              <div className="flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-4 py-3">
+                <BookOpen className="h-4 w-4 text-emerald-400 flex-shrink-0" />
+                <p className="text-sm text-emerald-300">
+                  This will be a fully theory-based quiz (100% theory) — questions are drawn from the concepts in your uploaded document(s).
+                </p>
+              </div>
+            ) : (
+              <>
+                <div className="flex items-center justify-between">
+                  <Label className="text-foreground">Question Distribution</Label>
+                </div>
+                <CodeTheorySlider
+                  codePercentage={codePercentage}
+                  onCodePercentageChange={setCodePercentage}
+                  mode={roleType}
+                />
+              </>
+            )}
           </div>
         </div>
 

--- a/src/components/CreateQuizCard/parts/FileUpload.tsx
+++ b/src/components/CreateQuizCard/parts/FileUpload.tsx
@@ -21,13 +21,15 @@ interface FileUploadProps {
   onChange: (files: UploadedFile[]) => void;
   maxFiles?: number;
   accept?: string;
+  description?: string;
 }
 
-export default function FileUpload({ 
-  value = [], 
-  onChange, 
+export default function FileUpload({
+  value = [],
+  onChange,
   maxFiles = 1,
-  accept = ".txt,.pdf,.docx,.md,.js,.ts,.jsx,.tsx,.py,.java,.cpp,.c,.cs,.go,.rs,.php,.rb,.swift,.kt,.scala,.pl,.hs,.m,.r,.sql,.html,.css,.json,.xml,.yaml,.yml,.pdf,.doc,.docx"
+  accept = ".txt,.pdf,.docx,.md,.js,.ts,.jsx,.tsx,.py,.java,.cpp,.c,.cs,.go,.rs,.php,.rb,.swift,.kt,.scala,.pl,.hs,.m,.r,.sql,.html,.css,.json,.xml,.yaml,.yml,.pdf,.doc,.docx",
+  description = "Upload a code file, documentation, or any text file to generate quiz questions from its content."
 }: FileUploadProps) {
   const [dragActive, setDragActive] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -66,7 +68,7 @@ export default function FileUpload({
     if (value.length >= maxFiles) {
       toast({
         title: "Maximum files reached",
-        description: `You can only upload up to ${maxFiles} file.`,
+        description: `You can only upload up to ${maxFiles} file${maxFiles > 1 ? "s" : ""}.`,
         variant: "destructive",
       });
       return;
@@ -272,11 +274,11 @@ const getFileIcon = (fileName: string) => {
       <div className="space-y-2">
         <Label className="text-foreground font-medium flex items-center gap-2">
           <Upload className="h-4 w-4" />
-          Upload File 
+          Upload File{maxFiles > 1 ? "s" : ""}
           <span className="text-red-500 ml-1">*</span>
         </Label>
         <p className="text-sm text-muted-foreground">
-          Upload a code file, documentation, or any text file to generate quiz questions from its content.
+          {description}
         </p>
       </div>
 
@@ -325,10 +327,10 @@ const getFileIcon = (fileName: string) => {
             
             <div className="space-y-3">
               <p className="text-lg font-semibold text-foreground">
-                {isUploading ? "Uploading file..." : dragActive ? "Drop file here!" : "Drag & drop file here"}
+                {isUploading ? "Uploading..." : dragActive ? "Drop files here!" : `Drag & drop file${maxFiles > 1 ? "s" : ""} here`}
               </p>
               <p className="text-sm text-muted-foreground">
-                {isUploading ? "Please wait while we process your file" : "or click to browse your files"}
+                {isUploading ? "Please wait while we process your file(s)" : "or click to browse your files"}
               </p>
             </div>
             
@@ -352,23 +354,23 @@ const getFileIcon = (fileName: string) => {
                 ) : (
                   <>
                     <Upload className="h-4 w-4 mr-2" />
-                    Select File
+                    Select File{maxFiles > 1 ? "s" : ""}
                   </>
                 )}
               </Button>
-              
+
               <input
                 ref={fileInputRef}
                 id="file-input"
                 type="file"
-                multiple={false}
+                multiple={maxFiles > 1}
                 accept={accept}
                 onChange={handleFileInput}
                 className="hidden"
                 disabled={value.length >= maxFiles || isUploading}
               />
             </div>
-            
+
             <div className="space-y-2 text-xs text-muted-foreground">
               <p className="flex items-center justify-center gap-2">
                 <span className="font-medium">Supported formats:</span>
@@ -378,8 +380,8 @@ const getFileIcon = (fileName: string) => {
                 <span className="bg-muted/70 px-2 py-1 rounded">Document files</span>
               </p>
               <p className="flex items-center justify-center gap-4">
-                <span>Max size: <strong>15MB</strong></span>
-                <span>Max file: <strong>1</strong></span>
+                <span>Max size: <strong>15MB each</strong></span>
+                <span>Max files: <strong>{maxFiles}</strong></span>
               </p>
             </div>
           </div>
@@ -391,7 +393,7 @@ const getFileIcon = (fileName: string) => {
         <div className="space-y-3">
           <Label className="text-foreground font-medium flex items-center gap-2">
             <CheckCircle2 className="h-4 w-4 text-green-500 animate-pulse" />
-            Uploaded File ({value.length})
+            Uploaded File{value.length > 1 ? "s" : ""} ({value.length})
           </Label>
           <div className="space-y-2">
             {value.map((uploadedFile, index) => (

--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -66,6 +66,7 @@ import { useCompanyInfo } from "@/hooks/useCompanyInfo";
 import Link from "next/link";
 
 type QuizResult = {
+  id?: number;
   quiz_id: string;
   owner_id: string;
   username: string;
@@ -433,33 +434,33 @@ export default function ResultsDashboard() {
   const handleDeleteSelectedUsers = async () => {
     if (!showDeleteUsersModal.quizId) return;
 
-    const toDelete = Object.entries(selectedUsers)
+    // Selection is now keyed per-attempt (row id), so each selected key deletes exactly
+    // that one attempt — other attempts by the same candidate are left untouched.
+    const selectedKeys = Object.entries(selectedUsers)
       .filter(([, v]) => v)
-      .map(([k]) => {
-        const [username, email] = k.split("|");
-        return { username, email };
-      });
+      .map(([k]) => k);
 
     try {
       setIsDeleting(true);
-      
+
       // Get auth token using Clerk's getToken method
       const token = await getToken();
-      
+
       if (!token) {
         throw new Error("No authentication token available");
       }
-      
+
       const headers = {
         'Authorization': `Bearer ${token}`,
       };
-      
-      const promises = toDelete.map(({ email }) =>
-        fetch(
-          `/api/quiz_result/delete?quiz_id=${showDeleteUsersModal.quizId}&email=${encodeURIComponent(email)}&company_id=${finalCompanyId}`,
-          { method: "DELETE", headers }
-        )
-      );
+
+      const promises = selectedKeys.map((key) => {
+        const attemptId = Number(key);
+        const url = Number.isFinite(attemptId)
+          ? `/api/quiz_result/delete?attempt_id=${attemptId}&company_id=${finalCompanyId}`
+          : `/api/quiz_result/delete?quiz_id=${showDeleteUsersModal.quizId}&email=${encodeURIComponent(key.split("|")[1] || "")}&company_id=${finalCompanyId}`;
+        return fetch(url, { method: "DELETE", headers });
+      });
 
       const responses = await Promise.all(promises);
       const failed = responses.filter((r) => !r.ok);
@@ -848,7 +849,9 @@ export default function ResultsDashboard() {
                                         filteredCandidates
                                           .sort((a, b) => b.result.score - a.result.score)
                                           .map((c) => {
-                                            const key = `${c.username}|${c.user_email}`;
+                                            // Keyed per-attempt (row id) — falls back to a composite
+                                            // key only if an older cached response lacks `id`.
+                                            const key = c.id != null ? String(c.id) : `${c.quiz_id}|${c.user_email}|${c.attempt}`;
                                             return (
                                               <TableRow
                                                 key={key}

--- a/src/pages/dashboard/my-quizzes/index.tsx
+++ b/src/pages/dashboard/my-quizzes/index.tsx
@@ -47,6 +47,7 @@ interface QuizSummary {
   theory_questions_percentage: number;
   code_analysis_questions_percentage: number;
   quiz: string;
+  quiz_type?: 'technical' | 'non_technical';
   created_at?: string;
   is_publish?: boolean;
   isPublished?: boolean;
@@ -286,6 +287,11 @@ export default function MyQuizzesPage() {
                                 )}
                               </div>
                               <div className="flex items-center gap-2">
+                                <Badge className={q.quiz_type === 'non_technical'
+                                  ? "bg-purple-600/20 text-purple-300 border border-purple-500/30"
+                                  : "bg-cyan-600/20 text-cyan-300 border border-cyan-500/30"}>
+                                  {q.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}
+                                </Badge>
                                 <Badge className="bg-blue-600/20 text-blue-300 border border-blue-500/30">{q.experience} yrs</Badge>
                               </div>
                             </div>
@@ -299,9 +305,11 @@ export default function MyQuizzesPage() {
                                 <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-emerald-300 text-xs">
                                   Theory {q.theory_questions_percentage}%
                                 </span>
-                                <span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-indigo-300 text-xs">
-                                  Code {q.code_analysis_questions_percentage}%
-                                </span>
+                                {q.quiz_type !== 'non_technical' && (
+                                  <span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-indigo-300 text-xs">
+                                    Code {q.code_analysis_questions_percentage}%
+                                  </span>
+                                )}
                               </div>
                               
                               <div className="mt-1">


### PR DESCRIPTION
… per-attempt delete

CreateQuizCard:
- Non-technical loading/reasoning text no longer mentions code-analysis or tech-stack balancing — uses its own document-reading step copy.
- Non-technical mode drops the Code/Theory split slider entirely (quiz is always 100% theory) and shows a clear "this will be a theory-based quiz" banner instead of the previous duplicated upload description text.
- File upload now supports up to 3 files (15MB each) for both technical file-upload mode and non-technical mode; wired through useCreateQuizV2 and /api/quiz/file to the backend's new multi-file endpoint.

My Quizzes page:
- Added a Technical/Non-Technical badge per quiz card, and hide the "Code %" chip for non-technical quizzes (always 0%, not meaningful to show).

Analytics page:
- Fixed a bug where selecting one attempt for a candidate with multiple attempts on the same quiz highlighted/selected all of that candidate's attempts (selection was keyed by username|email only, not per-attempt). Now keyed by the attempt's row id.
- "Delete selected" now deletes only the specific selected attempt(s) via the new backend per-attempt delete endpoint, instead of deleting every attempt the candidate has on that quiz.
- Added attempt_id support to the /api/quiz_result/delete proxy route.