### PR TITLE
feat: link users to their company instead of a per-user plan editor, …

### DIFF
--- a/src/app/admin/(protected)/companies/[companyId]/page.tsx
+++ b/src/app/admin/(protected)/companies/[companyId]/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Trash2, Save } from 'lucide-react';
+import { computePeriodEnd } from '@/lib/billingCycle';
 
 interface CustomLimits {
   maxQuizzes?: number;
@@ -63,6 +64,51 @@ export default function AdminCompanyDetailPage() {
   const update = (patch: Partial<Company>) => setCompany((prev) => prev ? { ...prev, ...patch } : prev);
   const updateLimits = (patch: Partial<CustomLimits>) =>
     setCompany((prev) => prev ? { ...prev, custom_limits: { ...(prev.custom_limits || {}), ...patch } } : prev);
+
+  // Live, in-browser preview of the same deterministic date math the backend
+  // applies on save: monthly -> +1 month from the start date, quarterly -> +3,
+  // half_yearly -> +6, yearly -> +12 — anchored to the exact start day, not a
+  // calendar-month boundary. Recomputes automatically whenever the plan,
+  // billing cycle, or start date changes; still overridable by hand afterward.
+  const recomputeExpiry = (planStartDate: string | null, billingCycle: string) => {
+    if (!planStartDate) return null;
+    const start = new Date(`${planStartDate}T00:00:00Z`);
+    if (Number.isNaN(start.getTime())) return null;
+    return computePeriodEnd(start, billingCycle).toISOString().slice(0, 10);
+  };
+
+  const handlePlanChange = (planName: string) => {
+    setCompany((prev) => {
+      if (!prev) return prev;
+      if (planName === 'Free') {
+        return { ...prev, plan_name: planName, billing_cycle: 'monthly', plan_expiry_date: null };
+      }
+      const startDate = prev.plan_start_date || new Date().toISOString().slice(0, 10);
+      const cycle = prev.billing_cycle || 'monthly';
+      return {
+        ...prev,
+        plan_name: planName,
+        plan_start_date: startDate,
+        billing_cycle: cycle,
+        plan_expiry_date: recomputeExpiry(startDate, cycle),
+      };
+    });
+  };
+
+  const handleBillingCycleChange = (billingCycle: string) => {
+    setCompany((prev) => {
+      if (!prev || prev.plan_name === 'Free') return prev;
+      return { ...prev, billing_cycle: billingCycle, plan_expiry_date: recomputeExpiry(prev.plan_start_date, billingCycle) };
+    });
+  };
+
+  const handleStartDateChange = (startDate: string) => {
+    setCompany((prev) => {
+      if (!prev) return prev;
+      if (prev.plan_name === 'Free') return { ...prev, plan_start_date: startDate };
+      return { ...prev, plan_start_date: startDate, plan_expiry_date: recomputeExpiry(startDate, prev.billing_cycle || 'monthly') };
+    });
+  };
 
   const handleSave = async () => {
     if (!company) return;
@@ -159,7 +205,7 @@ export default function AdminCompanyDetailPage() {
             <label className="text-sm text-zinc-400">Plan</label>
             <select
               value={company.plan_name}
-              onChange={(e) => update({ plan_name: e.target.value })}
+              onChange={(e) => handlePlanChange(e.target.value)}
               className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white"
             >
               {PLAN_OPTIONS.map((p) => <option key={p} value={p}>{p}</option>)}
@@ -169,7 +215,7 @@ export default function AdminCompanyDetailPage() {
             <label className="text-sm text-zinc-400">Billing cycle</label>
             <select
               value={company.billing_cycle || 'monthly'}
-              onChange={(e) => update({ billing_cycle: e.target.value })}
+              onChange={(e) => handleBillingCycleChange(e.target.value)}
               disabled={company.plan_name === 'Free'}
               className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white disabled:opacity-50"
             >
@@ -184,7 +230,7 @@ export default function AdminCompanyDetailPage() {
             <input
               type="date"
               value={company.plan_start_date || ''}
-              onChange={(e) => update({ plan_start_date: e.target.value })}
+              onChange={(e) => handleStartDateChange(e.target.value)}
               className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white"
             />
           </div>
@@ -197,7 +243,9 @@ export default function AdminCompanyDetailPage() {
               disabled={company.plan_name === 'Free'}
               className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white disabled:opacity-50"
             />
-            <p className="text-xs text-zinc-600">Leave as-is to auto-compute from start date + cycle. Override to set a custom date.</p>
+            <p className="text-xs text-zinc-600">
+              Auto-computed from start date + billing cycle — {company.plan_name === 'Free' ? 'N/A for Free plan' : 'changing plan, cycle, or start date recalculates this automatically'}. You can still override it manually.
+            </p>
           </div>
         </div>
 

--- a/src/app/admin/(protected)/users/page.tsx
+++ b/src/app/admin/(protected)/users/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Search, Plus, Trash2, X } from 'lucide-react';
+import Link from 'next/link';
+import { Search, Plus, Trash2, X, Pencil, Check } from 'lucide-react';
 
 interface UserPlan {
   user_id: string;
@@ -9,19 +10,31 @@ interface UserPlan {
   email: string | null;
   first_name: string | null;
   company_id: string | null;
+  company_name: string | null;
+  company_plan_name: string | null;
+  company_plan_expiry_date: string | null;
   created_at: string;
   updated_at: string;
 }
 
-const PLAN_OPTIONS = ['Free', 'Growth', 'Scale', 'Enterprise'];
+function planBadgeClass(plan: string) {
+  switch (plan) {
+    case 'Enterprise': return 'bg-purple-500/15 text-purple-300 border-purple-500/30';
+    case 'Scale': return 'bg-blue-500/15 text-blue-300 border-blue-500/30';
+    case 'Growth': return 'bg-green-500/15 text-green-300 border-green-500/30';
+    default: return 'bg-zinc-500/15 text-zinc-300 border-zinc-500/30';
+  }
+}
 
 export default function AdminUsersPage() {
   const [users, setUsers] = useState<UserPlan[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [showCreate, setShowCreate] = useState(false);
-  const [form, setForm] = useState({ user_id: '', email: '', first_name: '', plan_name: 'Free', company_id: '' });
+  const [form, setForm] = useState({ user_id: '', email: '', first_name: '', company_id: '' });
   const [error, setError] = useState<string | null>(null);
+  const [editingCompanyFor, setEditingCompanyFor] = useState<string | null>(null);
+  const [companyIdDraft, setCompanyIdDraft] = useState('');
 
   const load = async (q: string) => {
     setIsLoading(true);
@@ -55,19 +68,25 @@ export default function AdminUsersPage() {
         return;
       }
       setShowCreate(false);
-      setForm({ user_id: '', email: '', first_name: '', plan_name: 'Free', company_id: '' });
+      setForm({ user_id: '', email: '', first_name: '', company_id: '' });
       load(search);
     } catch {
       setError('Something went wrong');
     }
   };
 
-  const handlePlanChange = async (userId: string, planName: string) => {
+  const startEditCompany = (u: UserPlan) => {
+    setEditingCompanyFor(u.user_id);
+    setCompanyIdDraft(u.company_id || '');
+  };
+
+  const saveCompany = async (userId: string) => {
     await fetch(`/api/admin/users/${encodeURIComponent(userId)}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ plan_name: planName }),
+      body: JSON.stringify({ company_id: companyIdDraft || null }),
     });
+    setEditingCompanyFor(null);
     load(search);
   };
 
@@ -118,30 +137,62 @@ export default function AdminUsersPage() {
               <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
             ) : users.length === 0 ? (
               <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">No users found</td></tr>
-            ) : users.map((u) => (
-              <tr key={u.user_id} className="hover:bg-zinc-900/60">
-                <td className="px-4 py-3">
-                  <div className="text-white font-medium">{u.first_name || '—'}</div>
-                  <div className="text-xs text-zinc-500">{u.email || u.user_id}</div>
-                </td>
-                <td className="px-4 py-3">
-                  <select
-                    value={u.plan_name}
-                    onChange={(e) => handlePlanChange(u.user_id, e.target.value)}
-                    className="rounded-md bg-zinc-900 border border-zinc-700 px-2 py-1 text-white text-sm"
-                  >
-                    {PLAN_OPTIONS.map((p) => <option key={p} value={p}>{p}</option>)}
-                  </select>
-                </td>
-                <td className="px-4 py-3 text-zinc-400">{u.company_id || '—'}</td>
-                <td className="px-4 py-3 text-zinc-400">{new Date(u.created_at).toLocaleDateString()}</td>
-                <td className="px-4 py-3 text-right">
-                  <button onClick={() => handleDelete(u.user_id)} className="text-zinc-500 hover:text-red-400">
-                    <Trash2 className="h-4 w-4" />
-                  </button>
-                </td>
-              </tr>
-            ))}
+            ) : users.map((u) => {
+              // The real plan/billing lives on the user's company — fall back to
+              // the legacy per-user value only when there's no company linked.
+              const effectivePlan = u.company_id ? (u.company_plan_name || 'Free') : u.plan_name;
+              return (
+                <tr key={u.user_id} className="hover:bg-zinc-900/60">
+                  <td className="px-4 py-3">
+                    <div className="text-white font-medium">{u.first_name || '—'}</div>
+                    <div className="text-xs text-zinc-500">{u.email || u.user_id}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className={`inline-block rounded-full border px-2.5 py-0.5 text-xs ${planBadgeClass(effectivePlan)}`}>
+                      {effectivePlan}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">
+                    {editingCompanyFor === u.user_id ? (
+                      <div className="flex items-center gap-1.5">
+                        <input
+                          autoFocus
+                          value={companyIdDraft}
+                          onChange={(e) => setCompanyIdDraft(e.target.value)}
+                          placeholder="company_id"
+                          className="rounded-md bg-zinc-900 border border-zinc-700 px-2 py-1 text-white text-xs w-32"
+                        />
+                        <button onClick={() => saveCompany(u.user_id)} className="text-green-400 hover:text-green-300">
+                          <Check className="h-3.5 w-3.5" />
+                        </button>
+                        <button onClick={() => setEditingCompanyFor(null)} className="text-zinc-500 hover:text-white">
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ) : u.company_id ? (
+                      <div className="flex items-center gap-1.5 group">
+                        <Link href={`/admin/companies/${encodeURIComponent(u.company_id)}`} className="text-green-400 hover:text-green-300">
+                          {u.company_name || u.company_id}
+                        </Link>
+                        <button onClick={() => startEditCompany(u)} className="text-zinc-600 hover:text-white opacity-0 group-hover:opacity-100">
+                          <Pencil className="h-3 w-3" />
+                        </button>
+                      </div>
+                    ) : (
+                      <button onClick={() => startEditCompany(u)} className="text-xs text-zinc-500 hover:text-white border border-dashed border-zinc-700 rounded px-2 py-0.5">
+                        + Assign company
+                      </button>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-zinc-400">{new Date(u.created_at).toLocaleDateString()}</td>
+                  <td className="px-4 py-3 text-right">
+                    <button onClick={() => handleDelete(u.user_id)} className="text-zinc-500 hover:text-red-400">
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>
@@ -155,7 +206,8 @@ export default function AdminUsersPage() {
             </div>
             <p className="text-xs text-zinc-500 mb-4">
               This creates/updates a plan record only — it does not create a Clerk login account.
-              Use the actual Clerk user id if linking to an existing account.
+              Use the actual Clerk user id if linking to an existing account. Plan/billing is managed
+              per-company from the Companies &amp; Billing page, not here.
             </p>
             {error && <div className="mb-3 text-sm text-red-400">{error}</div>}
             <div className="space-y-3">
@@ -163,9 +215,6 @@ export default function AdminUsersPage() {
               <input placeholder="Email" value={form.email} onChange={(e) => setForm({ ...form, email: e.target.value })} className="w-full rounded-lg bg-zinc-950 border border-zinc-700 px-3 py-2 text-white text-sm" />
               <input placeholder="First name" value={form.first_name} onChange={(e) => setForm({ ...form, first_name: e.target.value })} className="w-full rounded-lg bg-zinc-950 border border-zinc-700 px-3 py-2 text-white text-sm" />
               <input placeholder="Company ID (optional)" value={form.company_id} onChange={(e) => setForm({ ...form, company_id: e.target.value })} className="w-full rounded-lg bg-zinc-950 border border-zinc-700 px-3 py-2 text-white text-sm" />
-              <select value={form.plan_name} onChange={(e) => setForm({ ...form, plan_name: e.target.value })} className="w-full rounded-lg bg-zinc-950 border border-zinc-700 px-3 py-2 text-white text-sm">
-                {PLAN_OPTIONS.map((p) => <option key={p} value={p}>{p}</option>)}
-              </select>
             </div>
             <div className="flex justify-end gap-3 mt-5">
               <button onClick={() => setShowCreate(false)} className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800">Cancel</button>

--- a/src/app/api/admin/users/[userId]/route.ts
+++ b/src/app/api/admin/users/[userId]/route.ts
@@ -12,7 +12,11 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
     const fields: string[] = [];
     const values: any[] = [];
     let i = 1;
-    for (const col of ['plan_name', 'email', 'first_name', 'company_id']) {
+    // plan_name intentionally excluded — a user's real plan lives on their
+    // company (companies.plan_name), managed from the Companies & Billing page.
+    // Editing this flat per-user column directly doesn't affect billing/limits
+    // at all, so it's not exposed here to avoid a misleading "edit".
+    for (const col of ['email', 'first_name', 'company_id']) {
       if (col in body) {
         fields.push(`${col} = $${i}`);
         values.push(body[col]);

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -9,12 +9,21 @@ export async function GET(request: NextRequest) {
   const search = request.nextUrl.searchParams.get('q')?.trim() || '';
   try {
     const db = getAdminDb();
+    // A user's real plan/billing lives on their company, not on this legacy
+    // per-user plan_name column — join it in so the UI can show the company
+    // (and its actual plan) instead of offering a disconnected per-user editor.
+    const baseQuery = `
+      SELECT up.*, c.name AS company_name, c.plan_name AS company_plan_name,
+             c.plan_expiry_date AS company_plan_expiry_date
+      FROM user_plans up
+      LEFT JOIN companies c ON c.company_id = up.company_id
+    `;
     const result = search
       ? await db.query(
-          `SELECT * FROM user_plans WHERE email ILIKE $1 OR user_id ILIKE $1 OR first_name ILIKE $1 ORDER BY created_at DESC LIMIT 200`,
+          `${baseQuery} WHERE up.email ILIKE $1 OR up.user_id ILIKE $1 OR up.first_name ILIKE $1 ORDER BY up.created_at DESC LIMIT 200`,
           [`%${search}%`]
         )
-      : await db.query(`SELECT * FROM user_plans ORDER BY created_at DESC LIMIT 200`);
+      : await db.query(`${baseQuery} ORDER BY up.created_at DESC LIMIT 200`);
     return NextResponse.json({ users: result.rows });
   } catch (error: any) {
     return NextResponse.json({ error: error.message || 'Failed to fetch users' }, { status: 500 });


### PR DESCRIPTION
…live-compute billing dates

Users page: removed the "realtime" plan dropdown — editing user_plans.plan_name directly never affected real billing/limits (that lives on companies.plan_name), so it was a misleading no-op editor. Replaced with a company link/assignment: shows the user's company (falls back to a plain "assign company" control when unset) and displays plan as a read-only badge sourced from that company's actual plan. /api/admin/users now joins companies for name/plan/expiry, and the PATCH endpoint no longer accepts plan_name.

Companies & Billing detail page: picking a paid plan, billing cycle, or start date now recomputes the expiry date live in the browser (same add-months math the backend applies on save) instead of only updating after a round trip — verified in-browser: Growth+Monthly from 2026-01-26 -> auto-fills 2026-02-26, switching to Quarterly -> auto-updates to 2026-04-26. Still manually overridable afterward.