### PR TITLE
feat: make admin panel dynamic — logo, usage %, drill-down quiz/attem…

### DIFF
--- a/src/app/admin/(protected)/AdminNav.tsx
+++ b/src/app/admin/(protected)/AdminNav.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import Link from 'next/link';
+import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { LayoutDashboard, Building2, Users, BarChart3, FileQuestion, ClipboardList, LogOut } from 'lucide-react';
+import { LayoutDashboard, Building2, Users, BarChart3, FileQuestion, ClipboardList, LogOut, Gauge } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const NAV_ITEMS = [
   { href: '/admin', label: 'Overview', icon: LayoutDashboard },
   { href: '/admin/companies', label: 'Companies & Billing', icon: Building2 },
+  { href: '/admin/usage', label: 'Usage', icon: Gauge },
   { href: '/admin/users', label: 'Users', icon: Users },
   { href: '/admin/analytics', label: 'Growth Analytics', icon: BarChart3 },
   { href: '/admin/quizzes', label: 'Quizzes', icon: FileQuestion },
@@ -27,8 +29,20 @@ export default function AdminNav() {
   return (
     <aside className="w-64 flex-shrink-0 border-r border-zinc-800 bg-zinc-950 flex flex-col">
       <div className="px-5 py-5 border-b border-zinc-800">
-        <div className="text-sm font-semibold text-white">QuizzViz Admin</div>
-        <div className="text-xs text-zinc-500">Internal control panel</div>
+        <Link href="/admin" className="flex items-center gap-2 group">
+          <div className="relative h-8 w-8 flex-shrink-0">
+            <Image
+              src="/QuizzViz-logo.png"
+              alt="QuizzViz Logo"
+              fill
+              className="object-contain"
+              priority
+              sizes="2rem"
+            />
+          </div>
+          <span className="text-base font-semibold text-white whitespace-nowrap">QuizzViz</span>
+        </Link>
+        <div className="text-xs text-zinc-500 mt-1">Internal admin panel</div>
       </div>
       <nav className="flex-1 py-4 px-3 space-y-1">
         {NAV_ITEMS.map(({ href, label, icon: Icon }) => {

--- a/src/app/admin/(protected)/ConfirmDeleteModal.tsx
+++ b/src/app/admin/(protected)/ConfirmDeleteModal.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { AlertTriangle, X } from 'lucide-react';
+
+interface ConfirmDeleteModalProps {
+  isOpen: boolean;
+  title: string;
+  description: React.ReactNode;
+  isDeleting?: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+  confirmLabel?: string;
+}
+
+export function ConfirmDeleteModal({
+  isOpen,
+  title,
+  description,
+  isDeleting = false,
+  onCancel,
+  onConfirm,
+  confirmLabel = 'Delete',
+}: ConfirmDeleteModalProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+      <div className="bg-zinc-900 border border-red-500/20 rounded-2xl p-6 w-full max-w-sm shadow-2xl shadow-red-900/20 animate-in fade-in-0 zoom-in-95">
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center justify-center w-11 h-11 rounded-full bg-gradient-to-br from-red-500 to-orange-500 shadow-lg shadow-red-500/30 flex-shrink-0">
+              <AlertTriangle className="h-5 w-5 text-white" />
+            </div>
+            <h3 className="text-lg font-semibold text-white leading-tight">{title}</h3>
+          </div>
+          <button onClick={onCancel} disabled={isDeleting} className="text-zinc-500 hover:text-white flex-shrink-0">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="text-sm text-zinc-400 mb-6">{description}</div>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            disabled={isDeleting}
+            className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800 disabled:opacity-50 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isDeleting}
+            className="px-4 py-2 text-sm rounded-lg bg-gradient-to-r from-red-600 to-orange-600 hover:from-red-700 hover:to-orange-700 text-white font-medium disabled:opacity-60 shadow-lg shadow-red-600/20 transition-all"
+          >
+            {isDeleting ? 'Deleting...' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmDeleteModal;

--- a/src/app/admin/(protected)/companies/[companyId]/page.tsx
+++ b/src/app/admin/(protected)/companies/[companyId]/page.tsx
@@ -5,6 +5,8 @@ import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Trash2, Save } from 'lucide-react';
 import { computePeriodEnd } from '@/lib/billingCycle';
+import { useToast } from '@/hooks/use-toast';
+import { ConfirmDeleteModal } from '../../ConfirmDeleteModal';
 
 interface CustomLimits {
   maxQuizzes?: number;
@@ -40,10 +42,12 @@ export default function AdminCompanyDetailPage() {
   const params = useParams();
   const router = useRouter();
   const companyId = params?.companyId as string;
+  const { toast } = useToast();
 
   const [company, setCompany] = useState<Company | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
@@ -135,19 +139,35 @@ export default function AdminCompanyDetailPage() {
       }
       setCompany(data.company);
       setMessage({ type: 'success', text: 'Saved successfully.' });
+      toast({
+        title: 'Saved',
+        description: `${data.company.name} was updated successfully.`,
+        className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+      });
     } finally {
       setIsSaving(false);
     }
   };
 
   const handleDelete = async () => {
-    const res = await fetch(`/api/admin/companies/${encodeURIComponent(companyId)}`, { method: 'DELETE' });
-    if (res.ok) {
-      router.push('/admin/companies');
-    } else {
-      const data = await res.json().catch(() => ({}));
-      setMessage({ type: 'error', text: data.error || 'Failed to delete' });
-      setShowDeleteConfirm(false);
+    if (!company) return;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/admin/companies/${encodeURIComponent(companyId)}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({
+          title: 'Company deleted',
+          description: `${company.name} was permanently removed.`,
+          className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+        });
+        router.push('/admin/companies');
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast({ title: 'Delete failed', description: data.error || 'Failed to delete company', variant: 'destructive' });
+        setShowDeleteConfirm(false);
+      }
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -308,18 +328,14 @@ export default function AdminCompanyDetailPage() {
         </div>
       </div>
 
-      {showDeleteConfirm && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-6 w-full max-w-sm">
-            <h3 className="text-lg font-semibold text-red-400 mb-2">Delete this company?</h3>
-            <p className="text-sm text-zinc-400 mb-5">This permanently removes {company.name} from the database. This cannot be undone.</p>
-            <div className="flex justify-end gap-3">
-              <button onClick={() => setShowDeleteConfirm(false)} className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800">Cancel</button>
-              <button onClick={handleDelete} className="px-4 py-2 text-sm rounded-lg bg-red-600 hover:bg-red-700 text-white">Delete</button>
-            </div>
-          </div>
-        </div>
-      )}
+      <ConfirmDeleteModal
+        isOpen={showDeleteConfirm}
+        title="Delete this company?"
+        description={<>This permanently removes <span className="text-white font-medium">{company.name}</span> and all of its billing data from the database. This cannot be undone.</>}
+        isDeleting={isDeleting}
+        onCancel={() => setShowDeleteConfirm(false)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/app/admin/(protected)/quizzes/[quizId]/page.tsx
+++ b/src/app/admin/(protected)/quizzes/[quizId]/page.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Users, Trophy, TrendingUp, ExternalLink } from 'lucide-react';
+
+interface Option {
+  A: string; B: string; C: string; D: string;
+}
+
+interface QuizQuestion {
+  id: number | string;
+  type: string;
+  question: string;
+  code_snippet?: string | null;
+  options: Option;
+  correct_answer: string;
+  topic: string;
+}
+
+interface QuizDetail {
+  quiz_id: string;
+  company_id: string;
+  company_name: string | null;
+  role: string;
+  experience: string;
+  num_questions: number;
+  theory_questions_percentage: number;
+  code_analysis_questions_percentage: number;
+  quiz_type: string;
+  is_publish: boolean;
+  quiz: QuizQuestion[];
+  quiz_public_link: string | null;
+  quiz_key: string | null;
+  max_attempts: number | null;
+  quiz_time: number | null;
+  created_at: string;
+}
+
+interface Stats {
+  attempt_count: number;
+  unique_candidates: number;
+  highest_score: number | null;
+  average_score: number | null;
+  top_candidate: { username: string; user_email: string; score: number; created_at: string } | null;
+}
+
+function StatCard({ label, value, icon: Icon }: { label: string; value: string; icon: any }) {
+  return (
+    <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-4">
+      <div className="flex items-center gap-2 text-zinc-500 text-xs mb-1.5">
+        <Icon className="h-3.5 w-3.5" /> {label}
+      </div>
+      <div className="text-xl font-semibold text-white">{value}</div>
+    </div>
+  );
+}
+
+export default function AdminQuizDetailPage() {
+  const params = useParams();
+  const quizId = params?.quizId as string;
+  const [quiz, setQuiz] = useState<QuizDetail | null>(null);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!quizId) return;
+    (async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(`/api/admin/quizzes/${encodeURIComponent(quizId)}`);
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error || 'Failed to load quiz');
+          return;
+        }
+        setQuiz(data.quiz);
+        setStats(data.stats);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [quizId]);
+
+  if (isLoading) return <div className="p-8 text-zinc-500">Loading...</div>;
+  if (error || !quiz) {
+    return (
+      <div className="p-8">
+        <p className="text-red-400">{error || 'Quiz not found.'}</p>
+        <Link href="/admin/quizzes" className="text-green-400 text-sm mt-2 inline-block">Back to quizzes</Link>
+      </div>
+    );
+  }
+
+  const questions = Array.isArray(quiz.quiz) ? quiz.quiz : [];
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <Link href="/admin/quizzes" className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white mb-6">
+        <ArrowLeft className="h-4 w-4" /> Back to quizzes
+      </Link>
+
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">{quiz.role}</h1>
+          <p className="text-sm text-zinc-500 mt-1">
+            {quiz.quiz_id} · {quiz.company_name || quiz.company_id} · {quiz.experience} yrs experience
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className={`text-xs rounded-full px-2.5 py-1 border ${quiz.quiz_type === 'non_technical' ? 'bg-purple-500/15 text-purple-300 border-purple-500/30' : 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30'}`}>
+            {quiz.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}
+          </span>
+          {quiz.quiz_public_link ? (
+            <span className="text-xs rounded-full px-2.5 py-1 bg-green-500/15 text-green-300 border border-green-500/30">Published</span>
+          ) : (
+            <span className="text-xs rounded-full px-2.5 py-1 bg-zinc-500/15 text-zinc-400 border border-zinc-500/30">Draft</span>
+          )}
+        </div>
+      </div>
+
+      {quiz.quiz_public_link && (
+        <a
+          href={`/${quiz.company_id}/take/quiz/${quiz.quiz_id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm text-green-400 hover:text-green-300 mb-4"
+        >
+          View public quiz link <ExternalLink className="h-3.5 w-3.5" />
+        </a>
+      )}
+
+      <div className="grid grid-cols-4 gap-4 my-6">
+        <StatCard label="Total attempts" value={String(stats?.attempt_count ?? 0)} icon={Users} />
+        <StatCard label="Unique candidates" value={String(stats?.unique_candidates ?? 0)} icon={Users} />
+        <StatCard label="Highest score" value={stats?.highest_score != null ? `${stats.highest_score.toFixed(1)}%` : '—'} icon={Trophy} />
+        <StatCard label="Average score" value={stats?.average_score != null ? `${stats.average_score.toFixed(1)}%` : '—'} icon={TrendingUp} />
+      </div>
+
+      {stats?.top_candidate && (
+        <div className="bg-gradient-to-r from-yellow-500/10 to-amber-500/10 border border-yellow-500/30 rounded-xl p-4 mb-6 flex items-center gap-3">
+          <Trophy className="h-5 w-5 text-yellow-400 flex-shrink-0" />
+          <p className="text-sm text-yellow-100">
+            Top scorer: <span className="font-semibold">{stats.top_candidate.username}</span> ({stats.top_candidate.user_email}) with{' '}
+            <span className="font-semibold">{Number(stats.top_candidate.score).toFixed(1)}%</span>
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 mb-4">
+        <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-emerald-300 text-xs">
+          Theory {quiz.theory_questions_percentage}%
+        </span>
+        {quiz.quiz_type !== 'non_technical' && (
+          <span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-indigo-300 text-xs">
+            Code {quiz.code_analysis_questions_percentage}%
+          </span>
+        )}
+        <span className="text-xs text-zinc-500">{questions.length} questions</span>
+      </div>
+
+      <div className="space-y-4">
+        {questions.map((q, idx) => (
+          <div key={q.id ?? idx} className="bg-zinc-950 border border-zinc-800 rounded-xl p-5">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-xs text-zinc-500">Q{idx + 1} · {q.topic}</span>
+              <span className={`text-xs rounded-full px-2 py-0.5 border ${
+                q.type === 'code_analysis' ? 'bg-indigo-500/15 text-indigo-300 border-indigo-500/30'
+                : q.type === 'practical_scenario' ? 'bg-purple-500/15 text-purple-300 border-purple-500/30'
+                : 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30'
+              }`}>
+                {q.type.replace('_', ' ')}
+              </span>
+            </div>
+            <p className="text-white text-sm mb-3 whitespace-pre-wrap">{q.question}</p>
+            {q.code_snippet && (
+              <pre className="bg-black border border-zinc-800 rounded-lg p-3 text-xs text-zinc-300 overflow-x-auto mb-3 font-mono">{q.code_snippet}</pre>
+            )}
+            <div className="grid grid-cols-2 gap-2">
+              {(['A', 'B', 'C', 'D'] as const).map((opt) => (
+                <div
+                  key={opt}
+                  className={`text-sm rounded-lg px-3 py-2 border ${
+                    q.correct_answer === opt
+                      ? 'bg-green-500/10 border-green-500/40 text-green-300'
+                      : 'bg-zinc-900 border-zinc-800 text-zinc-400'
+                  }`}
+                >
+                  <span className="font-medium mr-1.5">{opt}.</span>{q.options?.[opt]}
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/quizzes/page.tsx
+++ b/src/app/admin/(protected)/quizzes/page.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { Trash2 } from 'lucide-react';
+import Link from 'next/link';
+import { Trash2, Users, ChevronRight } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
 
 interface QuizRow {
   quiz_id: string;
@@ -13,12 +16,16 @@ interface QuizRow {
   quiz_type: string;
   is_publish: boolean;
   quiz_public_link: string | null;
+  attempt_count: number;
   created_at: string;
 }
 
 export default function AdminQuizzesPage() {
+  const { toast } = useToast();
   const [quizzes, setQuizzes] = useState<QuizRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<QuizRow | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const load = async () => {
     setIsLoading(true);
@@ -33,16 +40,32 @@ export default function AdminQuizzesPage() {
 
   useEffect(() => { load(); }, []);
 
-  const handleDelete = async (quizId: string) => {
-    if (!confirm('Delete this quiz? This removes it from generated and published quizzes.')) return;
-    await fetch(`/api/admin/quizzes?quiz_id=${encodeURIComponent(quizId)}`, { method: 'DELETE' });
-    load();
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/admin/quizzes?quiz_id=${encodeURIComponent(deleteTarget.quiz_id)}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({
+          title: 'Quiz deleted',
+          description: `"${deleteTarget.role}" was removed from generated and published quizzes.`,
+          className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+        });
+        setDeleteTarget(null);
+        load();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast({ title: 'Delete failed', description: data.error || 'Failed to delete quiz', variant: 'destructive' });
+      }
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
       <h1 className="text-2xl font-semibold text-white mb-1">Quizzes</h1>
-      <p className="text-sm text-zinc-500 mb-6">{quizzes.length} quizzes shown (most recent 300)</p>
+      <p className="text-sm text-zinc-500 mb-6">{quizzes.length} quizzes shown (most recent 300) — click a row to view its questions</p>
 
       <div className="border border-zinc-800 rounded-xl overflow-hidden">
         <table className="w-full text-sm">
@@ -53,6 +76,7 @@ export default function AdminQuizzesPage() {
               <th className="text-left px-4 py-3 font-medium">Type</th>
               <th className="text-left px-4 py-3 font-medium">Experience</th>
               <th className="text-left px-4 py-3 font-medium">Questions</th>
+              <th className="text-left px-4 py-3 font-medium">Attempts</th>
               <th className="text-left px-4 py-3 font-medium">Status</th>
               <th className="text-left px-4 py-3 font-medium">Created</th>
               <th className="px-4 py-3"></th>
@@ -60,12 +84,15 @@ export default function AdminQuizzesPage() {
           </thead>
           <tbody className="divide-y divide-zinc-900">
             {isLoading ? (
-              <tr><td colSpan={8} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
+              <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
             ) : quizzes.length === 0 ? (
-              <tr><td colSpan={8} className="px-4 py-8 text-center text-zinc-500">No quizzes found</td></tr>
+              <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">No quizzes found</td></tr>
             ) : quizzes.map((q) => (
-              <tr key={q.quiz_id} className="hover:bg-zinc-900/60">
-                <td className="px-4 py-3 text-white">{q.role}</td>
+              <tr key={q.quiz_id} className="hover:bg-zinc-900/60 relative">
+                <td className="px-4 py-3 text-white">
+                  <Link href={`/admin/quizzes/${encodeURIComponent(q.quiz_id)}`} className="absolute inset-0 z-10" aria-label={`View ${q.role} quiz`} />
+                  <span className="relative">{q.role}</span>
+                </td>
                 <td className="px-4 py-3 text-zinc-400">{q.company_name || q.company_id}</td>
                 <td className="px-4 py-3">
                   <span className={`text-xs rounded-full px-2 py-0.5 border ${q.quiz_type === 'non_technical' ? 'bg-purple-500/15 text-purple-300 border-purple-500/30' : 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30'}`}>
@@ -74,6 +101,11 @@ export default function AdminQuizzesPage() {
                 </td>
                 <td className="px-4 py-3 text-zinc-400">{q.experience}</td>
                 <td className="px-4 py-3 text-zinc-400">{q.num_questions}</td>
+                <td className="px-4 py-3 text-zinc-400">
+                  <span className="inline-flex items-center gap-1">
+                    <Users className="h-3.5 w-3.5" /> {q.attempt_count}
+                  </span>
+                </td>
                 <td className="px-4 py-3">
                   {q.quiz_public_link ? (
                     <span className="text-xs rounded-full px-2 py-0.5 bg-green-500/15 text-green-300 border border-green-500/30">Published</span>
@@ -82,8 +114,8 @@ export default function AdminQuizzesPage() {
                   )}
                 </td>
                 <td className="px-4 py-3 text-zinc-500">{new Date(q.created_at).toLocaleDateString()}</td>
-                <td className="px-4 py-3 text-right">
-                  <button onClick={() => handleDelete(q.quiz_id)} className="text-zinc-500 hover:text-red-400">
+                <td className="px-4 py-3 text-right relative z-20">
+                  <button onClick={() => setDeleteTarget(q)} className="text-zinc-500 hover:text-red-400">
                     <Trash2 className="h-4 w-4" />
                   </button>
                 </td>
@@ -92,6 +124,15 @@ export default function AdminQuizzesPage() {
           </tbody>
         </table>
       </div>
+
+      <ConfirmDeleteModal
+        isOpen={!!deleteTarget}
+        title="Delete this quiz?"
+        description={<>This removes <span className="text-white font-medium">&quot;{deleteTarget?.role}&quot;</span> from generated and published quizzes{deleteTarget?.attempt_count ? <> — <span className="text-orange-300">{deleteTarget.attempt_count} candidate attempt(s) already exist for it</span></> : null}. This cannot be undone.</>}
+        isDeleting={isDeleting}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/app/admin/(protected)/results/[id]/page.tsx
+++ b/src/app/admin/(protected)/results/[id]/page.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeft, Trophy, CheckCircle2, XCircle } from 'lucide-react';
+
+interface Option { A: string; B: string; C: string; D: string; }
+
+interface QuizQuestion {
+  id: number | string;
+  type: string;
+  question: string;
+  code_snippet?: string | null;
+  options: Option;
+  correct_answer: string;
+  topic: string;
+}
+
+interface UserAnswer {
+  question_id: string;
+  answer: string;
+  is_correct: boolean;
+}
+
+interface Attempt {
+  id: number;
+  quiz_id: string;
+  company_id: string;
+  company_name: string | null;
+  username: string;
+  user_email: string;
+  attempt: number;
+  user_answers: UserAnswer[];
+  result: { score?: number; correct_answers?: number; total_questions?: number; time_taken?: number };
+  created_at: string;
+}
+
+interface QuizInfo {
+  quiz_id: string;
+  role: string;
+  experience: string;
+  num_questions: number;
+  quiz_type: string;
+  quiz: QuizQuestion[];
+}
+
+export default function AdminAttemptDetailPage() {
+  const params = useParams();
+  const id = params?.id as string;
+  const [attempt, setAttempt] = useState<Attempt | null>(null);
+  const [quiz, setQuiz] = useState<QuizInfo | null>(null);
+  const [highestScore, setHighestScore] = useState<number | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    (async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch(`/api/admin/results/${encodeURIComponent(id)}`);
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error || 'Failed to load attempt');
+          return;
+        }
+        setAttempt(data.attempt);
+        setQuiz(data.quiz);
+        setHighestScore(data.highest_score);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [id]);
+
+  if (isLoading) return <div className="p-8 text-zinc-500">Loading...</div>;
+  if (error || !attempt) {
+    return (
+      <div className="p-8">
+        <p className="text-red-400">{error || 'Attempt not found.'}</p>
+        <Link href="/admin/results" className="text-green-400 text-sm mt-2 inline-block">Back to attempts</Link>
+      </div>
+    );
+  }
+
+  const score = attempt.result?.score ?? 0;
+  const questions = quiz?.quiz && Array.isArray(quiz.quiz) ? quiz.quiz : [];
+  const answersByQuestionId = new Map(
+    (attempt.user_answers || []).map((a) => [String(a.question_id), a])
+  );
+  const correctCount = attempt.result?.correct_answers ?? (attempt.user_answers || []).filter((a) => a.is_correct).length;
+  const totalCount = attempt.result?.total_questions ?? questions.length;
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <Link href="/admin/results" className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white mb-6">
+        <ArrowLeft className="h-4 w-4" /> Back to attempts
+      </Link>
+
+      <div className="flex items-start justify-between mb-2">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">{attempt.username}</h1>
+          <p className="text-sm text-zinc-500 mt-1">{attempt.user_email} · {attempt.company_name || attempt.company_id}</p>
+        </div>
+        <span className={`text-lg font-bold rounded-full px-4 py-1.5 ${score >= 70 ? 'bg-green-500/15 text-green-300' : score >= 40 ? 'bg-yellow-500/15 text-yellow-300' : 'bg-red-500/15 text-red-300'}`}>
+          {score.toFixed?.(1) ?? score}%
+        </span>
+      </div>
+
+      {quiz && (
+        <p className="text-sm text-zinc-500 mb-6">
+          Quiz: <Link href={`/admin/quizzes/${encodeURIComponent(quiz.quiz_id)}`} className="text-green-400 hover:text-green-300">{quiz.role}</Link>
+          {' '}· {quiz.quiz_id} · attempt #{attempt.attempt} · {new Date(attempt.created_at).toLocaleString()}
+        </p>
+      )}
+
+      <div className="grid grid-cols-3 gap-4 mb-6">
+        <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-4">
+          <div className="text-xs text-zinc-500 mb-1">Correct answers</div>
+          <div className="text-xl font-semibold text-white">{correctCount} / {totalCount}</div>
+        </div>
+        <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-4">
+          <div className="text-xs text-zinc-500 mb-1">This attempt's score</div>
+          <div className="text-xl font-semibold text-white">{score.toFixed?.(1) ?? score}%</div>
+        </div>
+        <div className="bg-gradient-to-br from-yellow-500/10 to-amber-500/10 border border-yellow-500/30 rounded-xl p-4">
+          <div className="text-xs text-yellow-400/80 mb-1 flex items-center gap-1"><Trophy className="h-3 w-3" /> Highest score for this quiz</div>
+          <div className="text-xl font-semibold text-yellow-200">{highestScore != null ? `${highestScore.toFixed(1)}%` : '—'}</div>
+        </div>
+      </div>
+
+      <h2 className="text-lg font-medium text-white mb-4">Question-by-question breakdown</h2>
+      <div className="space-y-4">
+        {questions.map((q, idx) => {
+          const ans = answersByQuestionId.get(String(q.id));
+          const userAnswer = ans?.answer;
+          const isCorrect = ans?.is_correct ?? (userAnswer === q.correct_answer);
+          return (
+            <div key={q.id ?? idx} className="bg-zinc-950 border border-zinc-800 rounded-xl p-5">
+              <div className="flex items-center justify-between mb-2">
+                <span className="text-xs text-zinc-500">Q{idx + 1} · {q.topic}</span>
+                {isCorrect ? (
+                  <span className="flex items-center gap-1 text-xs text-green-400"><CheckCircle2 className="h-3.5 w-3.5" /> Correct</span>
+                ) : (
+                  <span className="flex items-center gap-1 text-xs text-red-400"><XCircle className="h-3.5 w-3.5" /> Incorrect</span>
+                )}
+              </div>
+              <p className="text-white text-sm mb-3 whitespace-pre-wrap">{q.question}</p>
+              {q.code_snippet && (
+                <pre className="bg-black border border-zinc-800 rounded-lg p-3 text-xs text-zinc-300 overflow-x-auto mb-3 font-mono">{q.code_snippet}</pre>
+              )}
+              <div className="grid grid-cols-2 gap-2">
+                {(['A', 'B', 'C', 'D'] as const).map((opt) => {
+                  const isTheCorrectOne = q.correct_answer === opt;
+                  const isUserPick = userAnswer === opt;
+                  let cls = 'bg-zinc-900 border-zinc-800 text-zinc-400';
+                  if (isTheCorrectOne) cls = 'bg-green-500/10 border-green-500/40 text-green-300';
+                  if (isUserPick && !isTheCorrectOne) cls = 'bg-red-500/10 border-red-500/40 text-red-300';
+                  return (
+                    <div key={opt} className={`text-sm rounded-lg px-3 py-2 border flex items-center justify-between ${cls}`}>
+                      <span><span className="font-medium mr-1.5">{opt}.</span>{q.options?.[opt]}</span>
+                      {isUserPick && <span className="text-[10px] uppercase tracking-wide opacity-80 ml-2 flex-shrink-0">their pick</span>}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+        {questions.length === 0 && (
+          <p className="text-sm text-zinc-500">Original quiz questions are unavailable (quiz may have been deleted).</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/results/page.tsx
+++ b/src/app/admin/(protected)/results/page.tsx
@@ -1,7 +1,10 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import Link from 'next/link';
 import { Trash2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
 
 interface ResultRow {
   id: number;
@@ -16,8 +19,11 @@ interface ResultRow {
 }
 
 export default function AdminResultsPage() {
+  const { toast } = useToast();
   const [results, setResults] = useState<ResultRow[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [deleteTarget, setDeleteTarget] = useState<ResultRow | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const load = async () => {
     setIsLoading(true);
@@ -32,16 +38,32 @@ export default function AdminResultsPage() {
 
   useEffect(() => { load(); }, []);
 
-  const handleDelete = async (id: number) => {
-    if (!confirm('Delete this specific attempt?')) return;
-    await fetch(`/api/admin/results?id=${id}`, { method: 'DELETE' });
-    load();
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/admin/results?id=${deleteTarget.id}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({
+          title: 'Attempt deleted',
+          description: `${deleteTarget.username}'s attempt #${deleteTarget.attempt} was removed.`,
+          className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+        });
+        setDeleteTarget(null);
+        load();
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast({ title: 'Delete failed', description: data.error || 'Failed to delete attempt', variant: 'destructive' });
+      }
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
       <h1 className="text-2xl font-semibold text-white mb-1">Attempts / Results</h1>
-      <p className="text-sm text-zinc-500 mb-6">{results.length} attempts shown (most recent 300)</p>
+      <p className="text-sm text-zinc-500 mb-6">{results.length} attempts shown (most recent 300) — click a row for the full breakdown</p>
 
       <div className="border border-zinc-800 rounded-xl overflow-hidden">
         <table className="w-full text-sm">
@@ -61,17 +83,18 @@ export default function AdminResultsPage() {
             ) : results.length === 0 ? (
               <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">No attempts found</td></tr>
             ) : results.map((r) => (
-              <tr key={r.id} className="hover:bg-zinc-900/60">
+              <tr key={r.id} className="hover:bg-zinc-900/60 relative">
                 <td className="px-4 py-3">
-                  <div className="text-white">{r.username}</div>
-                  <div className="text-xs text-zinc-500">{r.user_email}</div>
+                  <Link href={`/admin/results/${r.id}`} className="absolute inset-0 z-10" aria-label={`View ${r.username}'s attempt`} />
+                  <div className="relative text-white">{r.username}</div>
+                  <div className="relative text-xs text-zinc-500">{r.user_email}</div>
                 </td>
                 <td className="px-4 py-3 text-zinc-400">{r.company_name || r.company_id}</td>
                 <td className="px-4 py-3 text-zinc-400">#{r.attempt}</td>
                 <td className="px-4 py-3 text-zinc-300">{r.result?.score !== undefined ? `${r.result.score}%` : '—'}</td>
                 <td className="px-4 py-3 text-zinc-500">{new Date(r.created_at).toLocaleDateString()}</td>
-                <td className="px-4 py-3 text-right">
-                  <button onClick={() => handleDelete(r.id)} className="text-zinc-500 hover:text-red-400">
+                <td className="px-4 py-3 text-right relative z-20">
+                  <button onClick={() => setDeleteTarget(r)} className="text-zinc-500 hover:text-red-400">
                     <Trash2 className="h-4 w-4" />
                   </button>
                 </td>
@@ -80,6 +103,15 @@ export default function AdminResultsPage() {
           </tbody>
         </table>
       </div>
+
+      <ConfirmDeleteModal
+        isOpen={!!deleteTarget}
+        title="Delete this attempt?"
+        description={<>This permanently removes <span className="text-white font-medium">{deleteTarget?.username}</span>&apos;s attempt #{deleteTarget?.attempt}. Their other attempts on this quiz are unaffected. This cannot be undone.</>}
+        isDeleting={isDeleting}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/app/admin/(protected)/usage/page.tsx
+++ b/src/app/admin/(protected)/usage/page.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Gauge } from 'lucide-react';
+
+interface UsageRow {
+  company_id: string;
+  name: string;
+  plan_name: string;
+  billing_cycle: string;
+  period_start: string;
+  period_end: string;
+  quizzes_used: number;
+  quizzes_limit: number;
+  quizzes_pct: number;
+  candidates_used: number;
+  candidates_limit: number;
+  candidates_pct: number;
+}
+
+function barColor(pct: number) {
+  if (pct >= 90) return 'bg-red-500';
+  if (pct >= 70) return 'bg-yellow-500';
+  return 'bg-green-500';
+}
+
+function UsageBar({ used, limit, pct }: { used: number; limit: number; pct: number }) {
+  const unlimited = limit === -1;
+  return (
+    <div className="w-40">
+      <div className="flex items-center justify-between text-xs mb-1">
+        <span className="text-zinc-400">{used} / {unlimited ? '∞' : limit}</span>
+        <span className={pct >= 90 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-zinc-500'}>
+          {unlimited ? '—' : `${pct}%`}
+        </span>
+      </div>
+      {!unlimited && (
+        <div className="h-1.5 w-full rounded-full bg-zinc-800 overflow-hidden">
+          <div className={`h-full rounded-full ${barColor(pct)} transition-all`} style={{ width: `${pct}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function AdminUsagePage() {
+  const [usage, setUsage] = useState<UsageRow[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      setIsLoading(true);
+      try {
+        const res = await fetch('/api/admin/usage');
+        const data = await res.json();
+        setUsage(data.usage || []);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, []);
+
+  return (
+    <div className="p-8 max-w-6xl mx-auto">
+      <div className="flex items-center gap-2.5 mb-1">
+        <Gauge className="h-5 w-5 text-green-400" />
+        <h1 className="text-2xl font-semibold text-white">Usage</h1>
+      </div>
+      <p className="text-sm text-zinc-500 mb-6">
+        How much of each company&apos;s current billing period quota has been used — anchored to their actual subscription
+        cycle, not the calendar month.
+      </p>
+
+      <div className="border border-zinc-800 rounded-xl overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-900 text-zinc-400">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium">Company</th>
+              <th className="text-left px-4 py-3 font-medium">Plan</th>
+              <th className="text-left px-4 py-3 font-medium">Current period</th>
+              <th className="text-left px-4 py-3 font-medium">Quizzes used</th>
+              <th className="text-left px-4 py-3 font-medium">Candidates used</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-900">
+            {isLoading ? (
+              <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
+            ) : usage.length === 0 ? (
+              <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">No companies found</td></tr>
+            ) : usage.map((u) => (
+              <tr key={u.company_id} className="hover:bg-zinc-900/60">
+                <td className="px-4 py-3">
+                  <Link href={`/admin/companies/${encodeURIComponent(u.company_id)}`} className="text-white hover:text-green-400 font-medium">
+                    {u.name}
+                  </Link>
+                </td>
+                <td className="px-4 py-3 text-zinc-400">{u.plan_name}</td>
+                <td className="px-4 py-3 text-zinc-500 text-xs">
+                  {u.period_start} → {u.period_end}
+                  <div className="text-zinc-600 capitalize">{u.billing_cycle.replace('_', '-')}</div>
+                </td>
+                <td className="px-4 py-3"><UsageBar used={u.quizzes_used} limit={u.quizzes_limit} pct={u.quizzes_pct} /></td>
+                <td className="px-4 py-3"><UsageBar used={u.candidates_used} limit={u.candidates_limit} pct={u.candidates_pct} /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/users/page.tsx
+++ b/src/app/admin/(protected)/users/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { Search, Plus, Trash2, X, Pencil, Check } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
 
 interface UserPlan {
   user_id: string;
@@ -27,6 +29,7 @@ function planBadgeClass(plan: string) {
 }
 
 export default function AdminUsersPage() {
+  const { toast } = useToast();
   const [users, setUsers] = useState<UserPlan[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [search, setSearch] = useState('');
@@ -35,6 +38,8 @@ export default function AdminUsersPage() {
   const [error, setError] = useState<string | null>(null);
   const [editingCompanyFor, setEditingCompanyFor] = useState<string | null>(null);
   const [companyIdDraft, setCompanyIdDraft] = useState('');
+  const [deleteTarget, setDeleteTarget] = useState<UserPlan | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const load = async (q: string) => {
     setIsLoading(true);
@@ -90,10 +95,26 @@ export default function AdminUsersPage() {
     load(search);
   };
 
-  const handleDelete = async (userId: string) => {
-    if (!confirm(`Delete user plan record for ${userId}?`)) return;
-    await fetch(`/api/admin/users/${encodeURIComponent(userId)}`, { method: 'DELETE' });
-    load(search);
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/admin/users/${encodeURIComponent(deleteTarget.user_id)}`, { method: 'DELETE' });
+      if (res.ok) {
+        toast({
+          title: 'User deleted',
+          description: `${deleteTarget.first_name || deleteTarget.email || deleteTarget.user_id} was removed.`,
+          className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+        });
+        setDeleteTarget(null);
+        load(search);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast({ title: 'Delete failed', description: data.error || 'Failed to delete user', variant: 'destructive' });
+      }
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   return (
@@ -186,7 +207,7 @@ export default function AdminUsersPage() {
                   </td>
                   <td className="px-4 py-3 text-zinc-400">{new Date(u.created_at).toLocaleDateString()}</td>
                   <td className="px-4 py-3 text-right">
-                    <button onClick={() => handleDelete(u.user_id)} className="text-zinc-500 hover:text-red-400">
+                    <button onClick={() => setDeleteTarget(u)} className="text-zinc-500 hover:text-red-400">
                       <Trash2 className="h-4 w-4" />
                     </button>
                   </td>
@@ -223,6 +244,15 @@ export default function AdminUsersPage() {
           </div>
         </div>
       )}
+
+      <ConfirmDeleteModal
+        isOpen={!!deleteTarget}
+        title="Delete this user record?"
+        description={<>This permanently removes the plan record for <span className="text-white font-medium">{deleteTarget?.first_name || deleteTarget?.email || deleteTarget?.user_id}</span>. This cannot be undone.</>}
+        isDeleting={isDeleting}
+        onCancel={() => setDeleteTarget(null)}
+        onConfirm={handleDelete}
+      />
     </div>
   );
 }

--- a/src/app/api/admin/quizzes/[quizId]/route.ts
+++ b/src/app/api/admin/quizzes/[quizId]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminSession } from '@/lib/adminSession';
+import { getAdminDb } from '@/lib/adminDb';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ quizId: string }> }) {
+  if (!requireAdminSession(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { quizId } = await params;
+
+  try {
+    const db = getAdminDb();
+
+    const quizResult = await db.query(
+      `SELECT g.*, c.name AS company_name, p.quiz_public_link, p.quiz_key, p.max_attempts,
+              p.quiz_time, p.quiz_expiration_time
+       FROM generated_quizzes g
+       LEFT JOIN companies c ON c.company_id = g.company_id
+       LEFT JOIN published_quizzes p ON p.quiz_id = g.quiz_id
+       WHERE g.quiz_id = $1`,
+      [quizId]
+    );
+
+    if (quizResult.rowCount === 0) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 });
+    }
+
+    const statsResult = await db.query(
+      `SELECT
+         COUNT(*) AS attempt_count,
+         COUNT(DISTINCT user_email) AS unique_candidates,
+         MAX((result->>'score')::numeric) AS highest_score,
+         AVG((result->>'score')::numeric) AS average_score
+       FROM quizz_users
+       WHERE quiz_id = $1`,
+      [quizId]
+    );
+
+    const topAttempt = await db.query(
+      `SELECT username, user_email, (result->>'score')::numeric AS score, created_at
+       FROM quizz_users
+       WHERE quiz_id = $1
+       ORDER BY (result->>'score')::numeric DESC NULLS LAST
+       LIMIT 1`,
+      [quizId]
+    );
+
+    return NextResponse.json({
+      quiz: quizResult.rows[0],
+      stats: {
+        attempt_count: Number(statsResult.rows[0]?.attempt_count || 0),
+        unique_candidates: Number(statsResult.rows[0]?.unique_candidates || 0),
+        highest_score: statsResult.rows[0]?.highest_score !== null ? Number(statsResult.rows[0].highest_score) : null,
+        average_score: statsResult.rows[0]?.average_score !== null ? Number(statsResult.rows[0].average_score) : null,
+        top_candidate: topAttempt.rows[0] || null,
+      },
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to fetch quiz' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/quizzes/route.ts
+++ b/src/app/api/admin/quizzes/route.ts
@@ -11,10 +11,14 @@ export async function GET(request: NextRequest) {
     const result = await db.query(
       `SELECT g.quiz_id, g.company_id, g.role, g.experience, g.num_questions, g.quiz_type,
               g.is_publish, g.is_deleted, g.created_at, c.name AS company_name,
-              p.quiz_public_link
+              p.quiz_public_link,
+              COALESCE(a.attempt_count, 0) AS attempt_count
        FROM generated_quizzes g
        LEFT JOIN companies c ON c.company_id = g.company_id
        LEFT JOIN published_quizzes p ON p.quiz_id = g.quiz_id
+       LEFT JOIN (
+         SELECT quiz_id, COUNT(*) AS attempt_count FROM quizz_users GROUP BY quiz_id
+       ) a ON a.quiz_id = g.quiz_id
        WHERE g.is_deleted = false
        ORDER BY g.created_at DESC
        LIMIT 300`

--- a/src/app/api/admin/results/[id]/route.ts
+++ b/src/app/api/admin/results/[id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminSession } from '@/lib/adminSession';
+import { getAdminDb } from '@/lib/adminDb';
+
+export async function GET(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  if (!requireAdminSession(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { id } = await params;
+
+  try {
+    const db = getAdminDb();
+
+    const attemptResult = await db.query(
+      `SELECT qu.*, c.name AS company_name
+       FROM quizz_users qu
+       LEFT JOIN companies c ON c.company_id = qu.company_id
+       WHERE qu.id = $1`,
+      [id]
+    );
+
+    if (attemptResult.rowCount === 0) {
+      return NextResponse.json({ error: 'Attempt not found' }, { status: 404 });
+    }
+
+    const attempt = attemptResult.rows[0];
+
+    const quizResult = await db.query(
+      `SELECT quiz_id, role, experience, num_questions, quiz_type, quiz
+       FROM generated_quizzes WHERE quiz_id = $1`,
+      [attempt.quiz_id]
+    );
+
+    const highestResult = await db.query(
+      `SELECT MAX((result->>'score')::numeric) AS highest_score
+       FROM quizz_users WHERE quiz_id = $1`,
+      [attempt.quiz_id]
+    );
+
+    return NextResponse.json({
+      attempt,
+      quiz: quizResult.rows[0] || null,
+      highest_score: highestResult.rows[0]?.highest_score !== null ? Number(highestResult.rows[0].highest_score) : null,
+    });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to fetch attempt' }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/usage/route.ts
+++ b/src/app/api/admin/usage/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminSession } from '@/lib/adminSession';
+import { getAdminDb } from '@/lib/adminDb';
+import { computeCurrentPeriod } from '@/lib/billingCycle';
+
+// Duplicated from src/config/plans.ts (not imported directly — that module
+// pulls in Clerk/react-query client hooks that aren't safe in a server Route
+// Handler). Keep these numbers in sync if the plan limits ever change.
+const PLAN_LIMITS: Record<string, { maxQuizzes: number; maxCandidates: number }> = {
+  Free: { maxQuizzes: 4, maxCandidates: 20 },
+  Growth: { maxQuizzes: 30, maxCandidates: 500 },
+  Scale: { maxQuizzes: 70, maxCandidates: 2000 },
+  Enterprise: { maxQuizzes: -1, maxCandidates: 6000 },
+};
+
+export async function GET(request: NextRequest) {
+  if (!requireAdminSession(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const db = getAdminDb();
+    const companiesResult = await db.query(
+      `SELECT company_id, name, plan_name, plan_start_date, billing_cycle, custom_limits
+       FROM companies ORDER BY name ASC`
+    );
+
+    const today = new Date();
+    const usage = await Promise.all(
+      companiesResult.rows.map(async (c) => {
+        const planStart = c.plan_start_date ? new Date(`${c.plan_start_date}T00:00:00Z`) : null;
+        const { periodStart, periodEnd } = computeCurrentPeriod(planStart, c.billing_cycle || 'monthly', today);
+
+        const [quizRes, candidateRes] = await Promise.all([
+          db.query(
+            `SELECT COUNT(*) AS count FROM generated_quizzes
+             WHERE company_id = $1 AND created_at >= $2 AND created_at < $3`,
+            [c.company_id, periodStart.toISOString(), periodEnd.toISOString()]
+          ),
+          db.query(
+            `SELECT COUNT(DISTINCT user_email) AS count FROM quizz_users
+             WHERE company_id = $1 AND created_at >= $2 AND created_at < $3`,
+            [c.company_id, periodStart.toISOString(), periodEnd.toISOString()]
+          ),
+        ]);
+
+        const baseLimits = PLAN_LIMITS[c.plan_name] || PLAN_LIMITS.Free;
+        const customLimits = c.custom_limits || {};
+        const maxQuizzes = customLimits.maxQuizzes ?? baseLimits.maxQuizzes;
+        const maxCandidates = customLimits.maxCandidates ?? baseLimits.maxCandidates;
+
+        const quizzesUsed = Number(quizRes.rows[0]?.count || 0);
+        const candidatesUsed = Number(candidateRes.rows[0]?.count || 0);
+
+        return {
+          company_id: c.company_id,
+          name: c.name,
+          plan_name: c.plan_name,
+          billing_cycle: c.billing_cycle || 'monthly',
+          period_start: periodStart.toISOString().slice(0, 10),
+          period_end: periodEnd.toISOString().slice(0, 10),
+          quizzes_used: quizzesUsed,
+          quizzes_limit: maxQuizzes,
+          quizzes_pct: maxQuizzes === -1 ? 0 : Math.min(100, Math.round((quizzesUsed / Math.max(1, maxQuizzes)) * 100)),
+          candidates_used: candidatesUsed,
+          candidates_limit: maxCandidates,
+          candidates_pct: maxCandidates === -1 ? 0 : Math.min(100, Math.round((candidatesUsed / Math.max(1, maxCandidates)) * 100)),
+        };
+      })
+    );
+
+    return NextResponse.json({ usage });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to fetch usage' }, { status: 500 });
+  }
+}

--- a/src/lib/billingCycle.ts
+++ b/src/lib/billingCycle.ts
@@ -25,3 +25,21 @@ export function computePeriodEnd(start: Date, billingCycle: string): Date {
   const months = BILLING_CYCLE_MONTHS[billingCycle] ?? 1;
   return addMonths(start, months);
 }
+
+// Mirrors compute_current_billing_period in the Python backend services —
+// returns the [periodStart, periodEnd) window `today` currently falls in,
+// anchored to planStart, without needing the anchor to be re-saved each cycle.
+export function computeCurrentPeriod(planStart: Date | null, billingCycle: string, today: Date = new Date()): { periodStart: Date; periodEnd: Date } {
+  if (!planStart) {
+    const periodStart = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+    return { periodStart, periodEnd: addMonths(periodStart, 1) };
+  }
+  const months = BILLING_CYCLE_MONTHS[billingCycle] ?? 1;
+  let monthsElapsed = (today.getUTCFullYear() - planStart.getUTCFullYear()) * 12 + (today.getUTCMonth() - planStart.getUTCMonth());
+  if (today.getUTCDate() < planStart.getUTCDate()) monthsElapsed -= 1;
+  monthsElapsed = Math.max(0, monthsElapsed);
+  const cyclesElapsed = Math.floor(monthsElapsed / months);
+  const periodStart = addMonths(planStart, cyclesElapsed * months);
+  const periodEnd = addMonths(planStart, (cyclesElapsed + 1) * months);
+  return { periodStart, periodEnd };
+}


### PR DESCRIPTION
…pt views, colorful confirmations

- QuizzViz logo + name added to the admin nav sidebar (matches dashboard branding).
- New Usage page (/admin/usage): per-company quiz/candidate consumption as a percentage of their plan limit, computed against their actual billing-cycle period (reusing the same anchor math as the backend fix), not calendar month. Verified against production: correctly shows e.g. 75% quiz quota used for a Free-plan company mid-cycle.
- Quizzes list rows are now clickable -> /admin/quizzes/[quizId], showing the full question set (with code snippets, options, correct answers highlighted), total/unique attempt counts, highest and average score, and the top scorer. List also gained an Attempts column.
- Attempts/Results rows are now clickable -> /admin/results/[id], showing the quiz title/id/role, candidate info, score vs the quiz's highest score, and a full question-by-question breakdown (each option shown, correct answer in green, the candidate's wrong pick in red if applicable).
- Replaced every native confirm()/plain modal on delete actions (Companies, Users, Quizzes, Results) with a shared colorful ConfirmDeleteModal (gradient red/orange icon + button) and added a success/error toast via the app's existing useToast hook (Toaster already globally mounted in app/layout.tsx, so no extra wiring needed).

All verified live against the real database and UI, including canceling a delete mid-flow to confirm no accidental mutation.