### PR TITLE
fix: quiz card/header badges, publish validation, topic-wise counts, …

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -868,12 +868,12 @@ const topicPerformance = calculateTopicWisePerformance();
       return [];
   }
 
-  // Group questions by their actual topic field
+  // Group questions by their actual topic field. Questions without a valid
+  // topic are bucketed under "General" instead of dropped, so the topic-wise
+  // total always matches the real question count shown in the score summary.
   const questionsByTopic = quizData.quiz.reduce((acc, question, index) => {
-    const topicName = question.topic?.trim();
-    if (!topicName || topicName === 'Unknown Topic' || topicName === '') {
-      return acc; // Skip questions without valid topic names
-    }
+    const trimmed = question.topic?.trim();
+    const topicName = (!trimmed || trimmed === 'Unknown Topic') ? 'General' : trimmed;
     if (!acc[topicName]) {
       acc[topicName] = [];
     }

--- a/src/app/api/admin/companies/[companyId]/route.ts
+++ b/src/app/api/admin/companies/[companyId]/route.ts
@@ -50,7 +50,16 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
 
     if (typeof body.name === 'string') setField('name', body.name);
     if (typeof body.company_size === 'string') setField('company_size', body.company_size);
-    if (typeof body.custom_limits === 'object') setField('custom_limits', body.custom_limits ? JSON.stringify(body.custom_limits) : null);
+    if (typeof body.custom_limits === 'object') {
+      // An object with no defined keys (e.g. every limit input was cleared,
+      // which JSON.stringify collapses to "{}") means "remove the override" —
+      // store real SQL NULL, not the literal string '{}', so it round-trips
+      // as null everywhere else that reads this column (including the
+      // Python Create_Company service, which fails response validation on a
+      // non-null-but-empty custom_limits value).
+      const hasValues = body.custom_limits && Object.keys(body.custom_limits).length > 0;
+      setField('custom_limits', hasValues ? JSON.stringify(body.custom_limits) : null);
+    }
 
     const planNameChanging = typeof body.plan_name === 'string' && body.plan_name !== existing.plan_name;
     const billingCycleProvided = typeof body.billing_cycle === 'string' && ALLOWED_BILLING_CYCLES.has(body.billing_cycle);

--- a/src/app/api/quiz/publish/route.ts
+++ b/src/app/api/quiz/publish/route.ts
@@ -129,13 +129,18 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ message: 'Authentication required' }, { status: 401 });
     }
 
-    // Calculate question type stats
+    // Calculate question type stats. Non-technical quizzes can have a
+    // 'practical_scenario' type alongside 'theory' — both count toward the
+    // theory percentage since the backend only tracks theory vs. code
+    // analysis. Derive theoryPercentage as the complement of
+    // codeAnalysisPercentage (rather than rounding both independently) so
+    // the two always sum to exactly 100, avoiding rounding-drift failures
+    // like 12.5%/87.5% -> 13 + 88 = 101.
     const totalQuestions = questions.length;
-    const theoryCount = questions.filter((q: any) => q.type === 'theory').length;
     const codeAnalysisCount = questions.filter((q: any) => q.type === 'code_analysis').length;
 
-    const theoryPercentage = Math.round((theoryCount / totalQuestions) * 100);
-    const codeAnalysisPercentage = Math.round((codeAnalysisCount / totalQuestions) * 100);
+    const codeAnalysisPercentage = totalQuestions > 0 ? Math.round((codeAnalysisCount / totalQuestions) * 100) : 0;
+    const theoryPercentage = 100 - codeAnalysisPercentage;
 
     // Use expiration date as-is (already converted to UTC in frontend)
     const formattedExpirationDate = expirationDate

--- a/src/components/Dashboard/PlanExpirationBanner.tsx
+++ b/src/components/Dashboard/PlanExpirationBanner.tsx
@@ -43,24 +43,29 @@ export function PlanExpirationBanner() {
   if (severity === 'expired') {
     message = `Your ${planName} plan expired on ${dateStr}. You can still view your data, but creating, publishing, or editing anything is disabled until you renew.`;
   } else if (daysLeft === 0) {
-    message = `Your ${planName} plan ends today (${dateStr}).`;
+    message = `Your ${planName} plan ends today (${dateStr}). Act now to avoid losing access.`;
   } else if (daysLeft === 1) {
-    message = `Your ${planName} plan ends tomorrow (${dateStr}).`;
+    message = `Your ${planName} plan ends tomorrow (${dateStr}). Act now to avoid losing access.`;
   } else {
-    message = `Your ${planName} plan ends in ${daysLeft} days (${dateStr}).`;
+    message = `Your ${planName} plan ends in ${daysLeft} days (${dateStr}). Renew soon to avoid any interruption.`;
   }
 
   return (
-    <div className={cn('flex items-center justify-between gap-3 border-b px-6 py-3 text-sm', style.wrap)}>
-      <div className="flex items-center gap-2.5">
-        <Icon className={cn('h-4 w-4 flex-shrink-0', style.iconClass)} />
-        <span>{message}</span>
+    <div
+      className={cn(
+        'flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 border-b-2 px-6 py-5 text-base shadow-md',
+        style.wrap
+      )}
+    >
+      <div className="flex items-center gap-3">
+        <Icon className={cn('h-7 w-7 flex-shrink-0', style.iconClass)} />
+        <span className="font-semibold leading-snug">{message}</span>
       </div>
       <Link
-        href="/pricing"
-        className="flex-shrink-0 rounded-md border border-white/20 bg-white/10 px-3 py-1.5 text-xs font-medium text-white hover:bg-white/20 transition-colors"
+        href="/contact"
+        className="flex-shrink-0 rounded-md border border-white/30 bg-white/10 px-5 py-2.5 text-sm font-bold text-white hover:bg-white/20 transition-colors whitespace-nowrap"
       >
-        {severity === 'expired' ? 'Renew Now' : 'Manage Plan'}
+        Contact QuizzViz Sales
       </Link>
     </div>
   );

--- a/src/components/Quiz/QuizHeader.tsx
+++ b/src/components/Quiz/QuizHeader.tsx
@@ -113,9 +113,16 @@ export function QuizHeader({
           </h1>
           <div className="mt-2 flex flex-wrap items-center gap-3 text-sm text-white/70">
             <Badge variant="secondary">{quiz.experience} yrs</Badge>
+            <Badge className={quiz.quiz_type === 'non_technical'
+              ? "bg-purple-600/20 text-purple-300 border border-purple-500/30"
+              : "bg-cyan-600/20 text-cyan-300 border border-cyan-500/30"}>
+              {quiz.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}
+            </Badge>
             <span>• {questionsCount} questions</span>
             <span>• Theory {quiz.theory_questions_percentage}%</span>
-            <span>• Code {quiz.code_analysis_questions_percentage}%</span>
+            {quiz.quiz_type !== 'non_technical' && (
+              <span>• Code {quiz.code_analysis_questions_percentage}%</span>
+            )}
           </div>
         </div>
         <div className="flex items-center gap-2 flex-wrap relative z-10 pointer-events-auto">

--- a/src/components/Quiz/types.ts
+++ b/src/components/Quiz/types.ts
@@ -13,6 +13,7 @@ export interface QuizSummary {
   created_at?: string;
   is_publish: boolean;
   quiz_key: string;
+  quiz_type?: 'technical' | 'non_technical';
 }
 
 export interface QuizQuestion {

--- a/src/lib/quizResult.ts
+++ b/src/lib/quizResult.ts
@@ -72,11 +72,12 @@ export class QuizResultAPI {
       }
 
       const questionsByTopic = quizData.quiz.reduce((acc: Record<string, QuestionWithAnswer[]>, question: any, index: number) => {
-        const topicName = question.topic?.trim();
-        if (!topicName || topicName === 'Unknown Topic' || topicName === '') {
-          return acc; // Skip questions without valid topic names
-        }
-        
+        // Bucket questions without a valid topic name under "General" instead
+        // of dropping them — otherwise the topic-wise total undercounts the
+        // real question total shown elsewhere on the page.
+        const trimmed = question.topic?.trim();
+        const topicName = (!trimmed || trimmed === 'Unknown Topic') ? 'General' : trimmed;
+
         if (!acc[topicName]) {
           acc[topicName] = [];
         }

--- a/src/pages/dashboard/my-quizzes/index.tsx
+++ b/src/pages/dashboard/my-quizzes/index.tsx
@@ -286,12 +286,7 @@ export default function MyQuizzesPage() {
                                   </div>
                                 )}
                               </div>
-                              <div className="flex items-center gap-2">
-                                <Badge className={q.quiz_type === 'non_technical'
-                                  ? "bg-purple-600/20 text-purple-300 border border-purple-500/30"
-                                  : "bg-cyan-600/20 text-cyan-300 border border-cyan-500/30"}>
-                                  {q.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}
-                                </Badge>
+                              <div className="flex items-center gap-2 shrink-0">
                                 <Badge className="bg-blue-600/20 text-blue-300 border border-blue-500/30">{q.experience} yrs</Badge>
                               </div>
                             </div>
@@ -302,6 +297,11 @@ export default function MyQuizzesPage() {
                           <CardContent>
                             <div className="flex flex-col gap-3">
                               <div className="flex flex-wrap gap-2">
+                                <Badge className={q.quiz_type === 'non_technical'
+                                  ? "bg-purple-600/20 text-purple-300 border border-purple-500/30"
+                                  : "bg-cyan-600/20 text-cyan-300 border border-cyan-500/30"}>
+                                  {q.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}
+                                </Badge>
                                 <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-emerald-300 text-xs">
                                   Theory {q.theory_questions_percentage}%
                                 </span>

--- a/src/pages/quiz/attempt/[quizId].tsx
+++ b/src/pages/quiz/attempt/[quizId].tsx
@@ -219,13 +219,15 @@ const QuizAttemptPage = () => {
       return [];
     }
 
-    // Group questions by their actual topics (only include questions with valid topic names)
+    // Group questions by their actual topics. Questions without a valid topic
+    // name are bucketed under "General" instead of being dropped — silently
+    // skipping them made the topic-wise totals undercount the real question
+    // count (e.g. 7/9 shown) even though the overall score above correctly
+    // used all 9 questions.
     const questionsByTopic = quizData.questions.reduce((acc, question, index) => {
-      const topicName = question.topic?.trim();
-      if (!topicName || topicName === 'Unknown Topic' || topicName === '') {
-        return acc; // Skip questions without valid topic names
-      }
-      
+      const trimmed = question.topic?.trim();
+      const topicName = (!trimmed || trimmed === 'Unknown Topic') ? 'General' : trimmed;
+
       if (!acc[topicName]) {
         acc[topicName] = [];
       }


### PR DESCRIPTION
…banners

- Move the Technical/Non-Technical badge off the quiz card title row (it was crowding the experience badge and making both unreadable) onto its own row with the Theory/Code tags; apply the same quiz_type-aware Code% hiding to QuizHeader (the quiz editor page), which was unconditionally showing a Code % for non-technical quizzes since `quiz_type` was missing from QuizSummary entirely.
- Fix non-technical quiz publish failing with "Sum of theory and code analysis percentages must be 100": the percentage calc only recognized 'theory'/'code_analysis' question types, so non-technical quizzes with 'practical_scenario' questions undercounted. Now derive theoryPercentage as the complement of codeAnalysisPercentage so they always sum to exactly 100, instead of rounding both independently (which could also drift, e.g. 12.5%/87.5% -> 13+88=101).
- Fix topic-wise performance undercounting the real question total (e.g. 7/9) on the candidate-facing attempt/results pages: questions with a missing/invalid topic were silently dropped from the breakdown instead of being bucketed, even though the overall score summary correctly counted all of them.
- Plan expiration banners: replace the Manage Plan/Renew Now link with a Contact QuizzViz Sales link, and make the banner larger and more prominent so it's harder to miss.