### PR TITLE
fix: invite flow stranding already-signed-in users, wrong onboarding …

### DIFF
--- a/src/app/accept_invite/page.tsx
+++ b/src/app/accept_invite/page.tsx
@@ -10,7 +10,7 @@ import { storeCompanyId } from '@/hooks/useCompanies';
 
 export default function AcceptInvitePage() {
   const router = useRouter();
-  const { user, isLoaded } = useUser();
+  const { user, isLoaded, isSignedIn } = useUser();
   const { getToken } = useAuth();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(true);
@@ -23,7 +23,7 @@ export default function AcceptInvitePage() {
     if (!isLoaded) return;
 
     // Check if user is signed in
-    if (!user) {
+    if (!isSignedIn) {
       // Redirect to signup page
       router.push('/signup');
       return;
@@ -38,7 +38,7 @@ export default function AcceptInvitePage() {
     }
 
     setIsLoading(false);
-  }, [isLoaded, user, router]);
+  }, [isLoaded, isSignedIn, router]);
 
   const handleAcceptInvite = async () => {
     const inviteToken = localStorage.getItem('invite-token');
@@ -144,13 +144,19 @@ export default function AcceptInvitePage() {
         ready = await isCompanyReady();
       }
 
-      localStorage.removeItem('invite-token');
-      if (ready) {
-        router.push('/dashboard');
-      } else {
-        console.error('No company info found after polling, redirecting to onboarding');
-        router.push('/onboarding');
+      if (!ready) {
+        // The poll is only used to time the loading screen — the invite was
+        // already confirmed accepted above (the API call succeeded and
+        // returned a company_id, which we've already written to
+        // storage/metadata), so there is a real company either way. Falling
+        // back to onboarding here would be wrong: it would ask a member who
+        // just joined a team to "create a company" instead of just giving
+        // the dashboard a moment to pick up what's already been set.
+        console.warn('Company readiness check timed out; proceeding to dashboard anyway.');
       }
+
+      localStorage.removeItem('invite-token');
+      router.push('/dashboard');
 
     } catch (error) {
       console.error('Error accepting invite:', error);

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -9,20 +9,20 @@ import { LoadingSpinner } from '@/components/ui/loading';
 export default function InvitePage() {
   const router = useRouter();
   const params = useParams();
-  const { user, isLoaded } = useUser();
+  const { isSignedIn, isLoaded } = useUser();
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     if (!isLoaded || !params.token) return;
 
     const token = Array.isArray(params.token) ? params.token[0] : params.token;
-    
+
     // Store invite token in localStorage immediately
     localStorage.setItem('invite-token', token);
-    
+
     // Add a small delay to ensure localStorage is set
     setTimeout(() => {
-      if (!user) {
+      if (!isSignedIn) {
         // No user signed in, redirect to signup
         router.push('/signup');
       } else {
@@ -31,7 +31,7 @@ export default function InvitePage() {
       }
       setIsLoading(false);
     }, 100);
-  }, [isLoaded, user, router, params.token]);
+  }, [isLoaded, isSignedIn, router, params.token]);
 
   if (!isLoaded || isLoading) {
     return (

--- a/src/pages/signin/[[...index]].tsx
+++ b/src/pages/signin/[[...index]].tsx
@@ -31,34 +31,24 @@ export default function SignInPage() {
 
   useEffect(() => {
     if (user) {
-      // Check if there's an auth intent from OAuth flow
-      const authIntent = typeof window !== 'undefined' ? sessionStorage.getItem('authIntent') : null;
-      
-      if (authIntent === 'signin') {
-        // User was trying to sign in but was already authenticated - redirect to dashboard
-        const hasCompany = user?.unsafeMetadata?.companyId || 
-                         (typeof window !== 'undefined' && localStorage.getItem('userCompanyId'));
-        
-        if (hasCompany) {
-          router.push("/dashboard");
-        } else {
-          router.push("/onboarding");
-        }
+      // A pending invite always takes priority: a signed-in user who ends up
+      // here with an unaccepted invite must continue on to accept it, not
+      // get silently bounced to dashboard/onboarding with the invite never
+      // consumed.
+      const inviteToken = typeof window !== 'undefined' ? localStorage.getItem('invite-token') : null;
+      if (inviteToken) {
+        setIsRedirecting(true);
+        router.push('/accept_invite');
         return;
       }
-      
-      // For regular signin page access, show the "already signed in" UI
-      // This handles cases where user manually navigates to signin while logged in
-    }
-  }, [user, router]);
 
-  useEffect(() => {
-    if (user) {
       setIsRedirecting(true);
-      // Check if user has company metadata, otherwise redirect to onboarding
-      const hasCompany = user?.unsafeMetadata?.companyId || 
+      // Any signed-in user landing on /signin (whether via the OAuth
+      // authIntent flow or by manually navigating here) belongs on
+      // dashboard/onboarding, not this form.
+      const hasCompany = user?.unsafeMetadata?.companyId ||
                        (typeof window !== 'undefined' && localStorage.getItem('userCompanyId'));
-      
+
       if (hasCompany) {
         router.push("/dashboard");
       } else {

--- a/src/pages/signup/[[...index]].tsx
+++ b/src/pages/signup/[[...index]].tsx
@@ -32,14 +32,25 @@ export default function SignUpPage() {
   // Handle redirect for authenticated users
   useEffect(() => {
     if (user) {
+      // A pending invite always takes priority: a signed-in user who lands
+      // here from an invite link (e.g. because the invite page's signed-in
+      // check raced with Clerk still hydrating) must continue on to accept
+      // the invite, not get stuck on the "already signed in" card or bounce
+      // to dashboard/onboarding with the invite silently un-accepted.
+      const inviteToken = typeof window !== 'undefined' ? localStorage.getItem('invite-token') : null;
+      if (inviteToken) {
+        router.push('/accept_invite');
+        return;
+      }
+
       // Check if there's an auth intent from OAuth flow
       const authIntent = typeof window !== 'undefined' ? sessionStorage.getItem('authIntent') : null;
-      
+
       if (authIntent === 'signup') {
         // User was trying to sign up but was already authenticated - redirect to dashboard
-        const hasCompany = user?.unsafeMetadata?.companyId || 
+        const hasCompany = user?.unsafeMetadata?.companyId ||
                          (typeof window !== 'undefined' && localStorage.getItem('userCompanyId'));
-        
+
         if (hasCompany) {
           router.push("/dashboard");
         } else {
@@ -47,7 +58,7 @@ export default function SignUpPage() {
         }
         return;
       }
-      
+
       // For regular signup page access, show the "already signed in" UI
       // This handles cases where user manually navigates to signup while logged in
     }


### PR DESCRIPTION
…redirect

Two distinct bugs in the invite-acceptance flow for existing QuizzViz users:

1. /invite/[token] used a truthy `user` check to decide signed-in vs signed-out; a Clerk hydration race could momentarily report an actually signed-in user as null, sending them to /signup instead of straight to /accept_invite. Once there, /signup's "already authenticated" effect only checked sessionStorage authIntent (set for OAuth flows) and otherwise just showed a static "you're already signed in" card — with no awareness of the pending invite-token sitting in localStorage, so the user got stuck with no path back to accepting their invite. /signin had a second, redundant effect that unconditionally redirected any signed-in user to dashboard/onboarding, with the same blind spot. Fixed by switching to Clerk's isSignedIn flag (the correct, race-resistant signal) and making both signup/signin check for a pending invite-token first, above any other redirect logic.

2. accept_invite's post-accept flow fell back to /onboarding if its readiness poll didn't confirm company data within 8 seconds — even though the invite had already been successfully accepted (the API call returned a company_id, already written to storage/metadata before the poll even started). Sending a freshly-joined member to "create a company" instead of the dashboard made no sense. Now always navigates to /dashboard after a successful accept; DashboardAccess already has a safe fallback for the rare case company info is genuinely missing.