### PR TITLE
fix: re-invited member sign-out loop, premature Free-plan limit banner

### DIFF
--- a/src/app/api/company-members/role/route.ts
+++ b/src/app/api/company-members/role/route.ts
@@ -87,13 +87,19 @@ export async function GET(request: NextRequest) {
           data: JSON.stringify(responseData, null, 2)
         });
         
-        // If member not found (404), check if user was deleted vs missing member record
+        // If member not found (404), check if user was deleted vs missing member record.
+        // IMPORTANT: this is only ever true if the backend explicitly says so —
+        // it must NOT be inferred from "member not found + not the owner", since
+        // that's also exactly what a freshly re-invited member looks like right
+        // after accepting (or any transient lookup race). Treating that as proof
+        // of deletion forces a sign-out that repeats on every dashboard visit,
+        // trapping a legitimately active member in a sign-out loop.
         if (response.status === 404) {
           // Check if this is a deleted member by looking at the response message
-          const isDeletedMember = responseData.message?.toLowerCase().includes('deleted') || 
+          const isDeletedMember = responseData.message?.toLowerCase().includes('deleted') ||
                                  responseData.error?.toLowerCase().includes('deleted') ||
                                  responseData.status === 'DELETED';
-          
+
           if (isDeletedMember) {
             console.log('Member has been deleted from the company');
             return NextResponse.json(
@@ -135,15 +141,18 @@ export async function GET(request: NextRequest) {
               if (isOwner) {
                 console.log('User is confirmed as company owner, will create OWNER record');
               } else {
-                console.log('User is not the company owner and member record not found - user was likely deleted');
-                // For non-owners who don't have a member record, they were likely deleted
+                console.log('User is not the company owner and no member record was found — passing through as a plain 404 (not treated as a deletion)');
+                // Do NOT assume this means the user was removed — that can't be
+                // distinguished from "not a member (yet)" purely from a missing
+                // row, and wrongly forcing a sign-out here traps re-invited or
+                // in-flight members in a loop. Let the caller treat this as an
+                // ordinary "no role for this company" result.
                 return NextResponse.json(
-                  { 
-                    error: 'Member has been deleted',
-                    deleted: true,
-                    message: 'You have been removed from this company'
+                  {
+                    error: 'Member not found in this company',
+                    message: responseData.detail || 'No membership record found for this user in this company'
                   },
-                  { status: 410 }
+                  { status: 404 }
                 );
               }
             } else {

--- a/src/components/CreateQuizCard/index.tsx
+++ b/src/components/CreateQuizCard/index.tsx
@@ -171,6 +171,11 @@ export default function CreateQuizCard({
     teamMembers: 0,
   };
   const planLimits = usePlanLimits(currentUsage);
+  // planLimits defaults to the Free plan's low cap while the real plan is
+  // still loading, so treat "limit reached" as unknown (false) until then —
+  // otherwise the primary Generate Quiz button could get disabled based on
+  // a placeholder plan the company isn't even on.
+  const quizLimitReached = !planLimits.isLoading && planLimits.isQuizLimitReached;
   const queryClient = useQueryClient();
   const router = useRouter();
   const { toast } = useToast();
@@ -315,7 +320,11 @@ export default function CreateQuizCard({
       <CardContent className="p-8 space-y-6">
         <QuizHeader />
 
-        {planLimits.isQuizLimitReached && (
+        {/* Don't show this until the real plan has loaded — planLimits
+            defaults to the Free plan's low cap while useUserPlan() is still
+            fetching, which could falsely flag "limit reached" against an
+            already-loaded usage count for a company on a higher plan. */}
+        {quizLimitReached && (
           <div className="p-4 bg-yellow-900/20 border border-yellow-700 rounded-lg text-yellow-200">
             <div className="flex items-start">
               <AlertTriangle className="h-5 w-5 mt-0.5 mr-2 flex-shrink-0" />
@@ -435,17 +444,17 @@ export default function CreateQuizCard({
                   <div>
                     <Button
                       className={`transition-all duration-300 px-5 py-2 rounded-lg shadow-md flex items-center ${
-                        planLimits.isQuizLimitReached
+                        quizLimitReached
                           ? "bg-yellow-600 hover:bg-yellow-700 text-white"
                           : "bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 duration-300 transition-all hover:to-blue-700 text-white"
                       }`}
                       disabled={
                         isMissingRequiredInput ||
-                        planLimits.isQuizLimitReached
+                        quizLimitReached
                       }
                       onClick={() => handleGenerateClick(codePercentage)}
                     >
-                      {planLimits.isQuizLimitReached ? (
+                      {quizLimitReached ? (
                         <>
                           <AlertTriangle className="h-4 w-4 mr-2" />
                           {getUpgradeCTA(plan as any).text}
@@ -466,7 +475,7 @@ export default function CreateQuizCard({
                   </div>
                 </TooltipTrigger>
                 {(isMissingRequiredInput ||
-                  planLimits.isQuizLimitReached) && (
+                  quizLimitReached) && (
                   <TooltipContent className="w-64 p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg">
                     <div className="space-y-2">
                       <div className="flex items-start">
@@ -485,12 +494,12 @@ export default function CreateQuizCard({
                         </div>
                         <div className="ml-3">
                           <p className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                            {planLimits.isQuizLimitReached
+                            {quizLimitReached
                               ? "Quiz Limit Reached"
                               : "Missing Information"}
                           </p>
                           <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                            {planLimits.isQuizLimitReached
+                            {quizLimitReached
                               ? `${getLimitMessage(
                                   "quiz",
                                   plan as any

--- a/src/hooks/usePlanLimits.ts
+++ b/src/hooks/usePlanLimits.ts
@@ -25,6 +25,10 @@ export interface LimitStatus {
   isQuizLimitReached: boolean;
   isCandidateLimitReached: boolean;
   isTeamMemberLimitReached: boolean;
+  // True while the real plan hasn't loaded yet — every "reached" flag above
+  // is computed against a Free-plan default in the meantime, so callers
+  // should treat those as not-yet-meaningful until this flips to false.
+  isLoading: boolean;
 }
 
 export function usePlanLimits(currentUsage?: CurrentUsage, customLimits?: {
@@ -35,8 +39,8 @@ export function usePlanLimits(currentUsage?: CurrentUsage, customLimits?: {
 }): LimitStatus {
   const { user } = useUser();
   const { companyInfo } = useCompanyInfo();
-  const { data: userPlanData } = useUserPlan();
-  
+  const { data: userPlanData, isLoading: isPlanLoading } = useUserPlan();
+
   const plan = userPlanData?.plan_name || 'Free';
   const planLimits = getPlanLimits(plan, customLimits);
   
@@ -72,7 +76,8 @@ export function usePlanLimits(currentUsage?: CurrentUsage, customLimits?: {
     teamMembersRemaining,
     isQuizLimitReached,
     isCandidateLimitReached,
-    isTeamMemberLimitReached
+    isTeamMemberLimitReached,
+    isLoading: isPlanLoading
   };
 }
 


### PR DESCRIPTION
- company-members/role: stop inferring "member was deleted" (which forces a Clerk sign-out + redirect to '/') purely from "404 + user isn't the company owner". The backend's actual 404 message never says "deleted", so this heuristic always fired for that combination regardless of cause — including a legitimately re-invited member whose membership row was just recreated. That trapped them in a sign-out loop on every dashboard visit. Now passes through a plain 404 with no `deleted` flag, so useUserRole treats it as an ordinary, non-blocking error instead.
- usePlanLimits: expose the real loading state from useUserPlan() instead of silently defaulting to the Free plan (and its low 4-quiz cap) while the actual company plan is still being fetched. CreateQuizCard was computing "quiz limit reached" — and disabling the Generate Quiz button — against that placeholder Free-plan default, which only self-corrected once the real plan finished loading a moment later. Introduced a single `quizLimitReached` value gated on the new isLoading flag and used it everywhere the raw flag was previously read directly.