### PR TITLE
fix: kicked members still had dashboard access after hard refresh; su…

### DIFF
--- a/src/app/api/company-members/invite/route.js
+++ b/src/app/api/company-members/invite/route.js
@@ -86,8 +86,13 @@ export async function POST(request) {
       });
       
       return NextResponse.json(
-        { 
-          error: responseData.message || `Failed to send invitation: ${response.statusText}`,
+        {
+          // FastAPI's HTTPException responses are shaped { "detail": "..." },
+          // not { "message": "..." } — read that first so specific backend
+          // errors (e.g. "This email is already a member of this company")
+          // actually reach the user instead of falling through to a generic
+          // message.
+          error: responseData.detail || responseData.message || `Failed to send invitation: ${response.statusText}`,
           details: responseData.details || responseData,
           status: response.status
         },

--- a/src/hooks/useUserRole.ts
+++ b/src/hooks/useUserRole.ts
@@ -102,8 +102,17 @@ export function useUserRole(companyId?: string): UseUserRoleReturn {
     },
     dependencies: [user?.id, companyId],
     cacheKey,
-    ttl: 10 * 60 * 1000, // 10 minutes cache for role data
-    usePersistentCache: true // Enable localStorage caching for role data
+    // This gates dashboard access, so it must never serve a stale "you're
+    // still an active member" result after a real membership change. A
+    // persisted (localStorage) cache defeated that: on a hard refresh,
+    // useCachedData would immediately hand back the pre-removal cached role
+    // — its 2s-later background refresh only logs a warning on failure and
+    // never updates state, so a kicked-out member's stale cache entry could
+    // keep granting access indefinitely. Disabled persistence and shortened
+    // the TTL so every fresh mount (hard refresh, new tab) always re-checks
+    // against the server instead of trusting old data.
+    ttl: 30 * 1000, // 30 seconds
+    usePersistentCache: false
   });
 
   // Store company_id in sessionStorage for member users when role is fetched


### PR DESCRIPTION
…rface invite errors properly

- useUserRole: disabled persistent (localStorage) caching and cut the TTL from 10 minutes to 30 seconds. On a hard refresh, useCachedData was immediately serving the pre-removal cached role from localStorage before ever checking the server — its background refresh only fires 2s later and silently swallows failures (just console.warn, never updates state) — so a kicked-out member's stale cache entry could keep granting access indefinitely, completely bypassing the 404-based removal detection added last session. This is a security-gating check; it must never trust cross-reload cached data.
- company-members/invite proxy route: was reading responseData.message for backend error text, but FastAPI's HTTPException responses are shaped { "detail": "..." } — so every backend error (including the new duplicate-invite check below) was silently replaced with a generic "Failed to send invitation" instead of reaching the user.