### PR TITLE
feat: expand admin panel with quiz management, customer email, and UX…

### DIFF
--- a/src/app/admin/(protected)/AdminNav.tsx
+++ b/src/app/admin/(protected)/AdminNav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { LayoutDashboard, Building2, Users, BarChart3, FileQuestion, ClipboardList, LogOut, Gauge } from 'lucide-react';
+import { LayoutDashboard, Building2, Users, BarChart3, FileQuestion, ClipboardList, LogOut, Gauge, Mail } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const NAV_ITEMS = [
@@ -14,6 +14,7 @@ const NAV_ITEMS = [
   { href: '/admin/analytics', label: 'Growth Analytics', icon: BarChart3 },
   { href: '/admin/quizzes', label: 'Quizzes', icon: FileQuestion },
   { href: '/admin/results', label: 'Attempts / Results', icon: ClipboardList },
+  { href: '/admin/email', label: 'Email Customers', icon: Mail },
 ];
 
 export default function AdminNav() {
@@ -29,18 +30,18 @@ export default function AdminNav() {
   return (
     <aside className="w-64 flex-shrink-0 border-r border-zinc-800 bg-zinc-950 flex flex-col">
       <div className="px-5 py-5 border-b border-zinc-800">
-        <Link href="/admin" className="flex items-center gap-2 group">
-          <div className="relative h-8 w-8 flex-shrink-0">
+        <Link href="/" className="flex items-center gap-2 group">
+          <div className="relative h-10 w-10 flex-shrink-0">
             <Image
               src="/QuizzViz-logo.png"
               alt="QuizzViz Logo"
               fill
               className="object-contain"
               priority
-              sizes="2rem"
+              sizes="2.5rem"
             />
           </div>
-          <span className="text-base font-semibold text-white whitespace-nowrap">QuizzViz</span>
+          <span className="text-xl font-semibold text-white whitespace-nowrap">QuizzViz</span>
         </Link>
         <div className="text-xs text-zinc-500 mt-1">Internal admin panel</div>
       </div>

--- a/src/app/admin/(protected)/email/page.tsx
+++ b/src/app/admin/(protected)/email/page.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Mail, Search, Send, X } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+interface Suggestion {
+  key: string;
+  email: string;
+  label: string;
+  sublabel: string;
+}
+
+export default function AdminEmailPage() {
+  const { toast } = useToast();
+  const [recipient, setRecipient] = useState('');
+  const [subject, setSubject] = useState('');
+  const [message, setMessage] = useState('');
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const boxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!recipient || recipient.includes('@')) {
+      setSuggestions([]);
+      return;
+    }
+    const t = setTimeout(async () => {
+      try {
+        const [companiesRes, usersRes] = await Promise.all([
+          fetch(`/api/admin/companies?q=${encodeURIComponent(recipient)}`),
+          fetch(`/api/admin/users?q=${encodeURIComponent(recipient)}`),
+        ]);
+        const companies = await companiesRes.json();
+        const users = await usersRes.json();
+
+        const companySuggestions: Suggestion[] = (companies.companies || [])
+          .filter((c: any) => c.owner_email)
+          .slice(0, 5)
+          .map((c: any) => ({ key: `c-${c.company_id}`, email: c.owner_email, label: c.name, sublabel: c.owner_email }));
+
+        const userSuggestions: Suggestion[] = (users.users || [])
+          .filter((u: any) => u.email)
+          .slice(0, 5)
+          .map((u: any) => ({ key: `u-${u.user_id}`, email: u.email, label: u.first_name || u.email, sublabel: u.company_name ? `${u.email} · ${u.company_name}` : u.email }));
+
+        const merged = [...companySuggestions, ...userSuggestions];
+        const seen = new Set<string>();
+        setSuggestions(merged.filter((s) => (seen.has(s.email) ? false : (seen.add(s.email), true))));
+      } catch {
+        setSuggestions([]);
+      }
+    }, 300);
+    return () => clearTimeout(t);
+  }, [recipient]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (boxRef.current && !boxRef.current.contains(e.target as Node)) {
+        setShowSuggestions(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const validate = (): string | null => {
+    if (!recipient.trim() || !recipient.includes('@')) return 'Enter a valid recipient email address.';
+    if (!subject.trim()) return 'Subject is required.';
+    if (!message.trim()) return 'Message is required.';
+    return null;
+  };
+
+  const handleReview = () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    setShowConfirm(true);
+  };
+
+  const handleSend = async () => {
+    setIsSending(true);
+    try {
+      const res = await fetch('/api/admin/send-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recipient_email: recipient.trim(), subject: subject.trim(), message: message.trim() }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast({ title: 'Send failed', description: data.error || 'Failed to send email', variant: 'destructive' });
+        setShowConfirm(false);
+        return;
+      }
+      toast({
+        title: 'Email sent',
+        description: `Your message was sent to ${recipient.trim()}.`,
+        className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+      });
+      setShowConfirm(false);
+      setRecipient('');
+      setSubject('');
+      setMessage('');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  return (
+    <div className="p-8 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-semibold text-white mb-1">Email Customers</h1>
+      <p className="text-sm text-zinc-500 mb-6">Send a one-off email directly to a company owner, user, or any address.</p>
+
+      <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-6 space-y-4">
+        {error && (
+          <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</div>
+        )}
+
+        <div className="relative" ref={boxRef}>
+          <label className="text-xs text-zinc-500 mb-1 block">To</label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
+            <input
+              value={recipient}
+              onChange={(e) => {
+                setRecipient(e.target.value);
+                setShowSuggestions(true);
+              }}
+              onFocus={() => setShowSuggestions(true)}
+              placeholder="Search by company, name, or type an email..."
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 pl-9 pr-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+          </div>
+          {showSuggestions && suggestions.length > 0 && (
+            <div className="absolute z-30 mt-1 w-full max-h-60 overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl">
+              {suggestions.map((s) => (
+                <button
+                  key={s.key}
+                  type="button"
+                  onClick={() => {
+                    setRecipient(s.email);
+                    setShowSuggestions(false);
+                  }}
+                  className="w-full text-left px-3 py-2 text-sm hover:bg-zinc-800"
+                >
+                  <div className="text-white">{s.label}</div>
+                  <div className="text-xs text-zinc-500">{s.sublabel}</div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div>
+          <label className="text-xs text-zinc-500 mb-1 block">Subject</label>
+          <input
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            placeholder="Subject"
+            className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+          />
+        </div>
+
+        <div>
+          <label className="text-xs text-zinc-500 mb-1 block">Message</label>
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Write your message..."
+            rows={8}
+            className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+          />
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            onClick={handleReview}
+            className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white text-sm font-medium px-4 py-2"
+          >
+            <Send className="h-4 w-4" /> Review &amp; Send
+          </button>
+        </div>
+      </div>
+
+      {showConfirm && (
+        <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
+          <div className="bg-zinc-900 border border-green-500/20 rounded-2xl p-6 w-full max-w-lg shadow-2xl shadow-green-900/20">
+            <div className="flex items-start justify-between mb-4">
+              <div className="flex items-center gap-3">
+                <div className="flex items-center justify-center w-11 h-11 rounded-full bg-gradient-to-br from-green-500 to-blue-500 shadow-lg shadow-green-500/30 flex-shrink-0">
+                  <Mail className="h-5 w-5 text-white" />
+                </div>
+                <h3 className="text-lg font-semibold text-white leading-tight">Send this email?</h3>
+              </div>
+              <button onClick={() => setShowConfirm(false)} disabled={isSending} className="text-zinc-500 hover:text-white flex-shrink-0">
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <div className="text-sm text-zinc-400 mb-6 space-y-2">
+              <p><span className="text-zinc-500">To:</span> <span className="text-white">{recipient}</span></p>
+              <p><span className="text-zinc-500">Subject:</span> <span className="text-white">{subject}</span></p>
+              <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-zinc-300">{message}</div>
+            </div>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setShowConfirm(false)}
+                disabled={isSending}
+                className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800 disabled:opacity-50 transition-colors"
+              >
+                Edit
+              </button>
+              <button
+                onClick={handleSend}
+                disabled={isSending}
+                className="px-4 py-2 text-sm rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white font-medium disabled:opacity-60 shadow-lg shadow-green-600/20 transition-all"
+              >
+                {isSending ? 'Sending...' : 'Confirm & Send'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/quizzes/QuizForm.tsx
+++ b/src/app/admin/(protected)/quizzes/QuizForm.tsx
@@ -1,0 +1,416 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Plus, Trash2, ChevronDown } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+
+type QuestionType = 'theory' | 'code_analysis' | 'practical_scenario';
+
+interface QuestionDraft {
+  key: string;
+  type: QuestionType;
+  question: string;
+  code_snippet: string;
+  options: { A: string; B: string; C: string; D: string };
+  correct_answer: 'A' | 'B' | 'C' | 'D';
+  topic: string;
+}
+
+interface CompanyOption {
+  company_id: string;
+  name: string;
+}
+
+export interface QuizFormInitialData {
+  quiz_id?: string;
+  company_id: string;
+  company_name?: string | null;
+  role: string;
+  experience: string;
+  quiz_type: string;
+  theory_questions_percentage?: number;
+  code_analysis_questions_percentage?: number;
+  quiz?: Array<{
+    id?: number | string;
+    type?: string;
+    question: string;
+    code_snippet?: string | null;
+    options: { A: string; B: string; C: string; D: string };
+    correct_answer: string;
+    topic?: string;
+  }>;
+}
+
+function emptyQuestion(): QuestionDraft {
+  return {
+    key: Math.random().toString(36).slice(2),
+    type: 'theory',
+    question: '',
+    code_snippet: '',
+    options: { A: '', B: '', C: '', D: '' },
+    correct_answer: 'A',
+    topic: '',
+  };
+}
+
+function toDrafts(initial?: QuizFormInitialData['quiz']): QuestionDraft[] {
+  if (!initial || initial.length === 0) return [emptyQuestion()];
+  return initial.map((q) => ({
+    key: Math.random().toString(36).slice(2),
+    type: (q.type as QuestionType) || 'theory',
+    question: q.question || '',
+    code_snippet: q.code_snippet || '',
+    options: { A: q.options?.A || '', B: q.options?.B || '', C: q.options?.C || '', D: q.options?.D || '' },
+    correct_answer: (q.correct_answer as 'A' | 'B' | 'C' | 'D') || 'A',
+    topic: q.topic || '',
+  }));
+}
+
+export function QuizForm({
+  mode,
+  initialData,
+  onCancel,
+  onSaved,
+}: {
+  mode: 'create' | 'edit';
+  initialData?: QuizFormInitialData;
+  onCancel?: () => void;
+  onSaved: (quizId: string) => void;
+}) {
+  const { toast } = useToast();
+  const [companyId, setCompanyId] = useState(initialData?.company_id || '');
+  const [companyQuery, setCompanyQuery] = useState(initialData?.company_name || initialData?.company_id || '');
+  const [companyOptions, setCompanyOptions] = useState<CompanyOption[]>([]);
+  const [showCompanyDropdown, setShowCompanyDropdown] = useState(false);
+  const [role, setRole] = useState(initialData?.role || '');
+  const [experience, setExperience] = useState(initialData?.experience || '');
+  const [quizType, setQuizType] = useState(initialData?.quiz_type || 'technical');
+  const [theoryPct, setTheoryPct] = useState(initialData?.theory_questions_percentage ?? 70);
+  const [codePct, setCodePct] = useState(initialData?.code_analysis_questions_percentage ?? 30);
+  const [questions, setQuestions] = useState<QuestionDraft[]>(toDrafts(initialData?.quiz));
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const companyBoxRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!companyQuery || companyQuery === initialData?.company_name || companyQuery === companyId) return;
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/admin/companies?q=${encodeURIComponent(companyQuery)}`);
+        const data = await res.json();
+        setCompanyOptions((data.companies || []).slice(0, 8));
+      } catch {
+        setCompanyOptions([]);
+      }
+    }, 300);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [companyQuery]);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (companyBoxRef.current && !companyBoxRef.current.contains(e.target as Node)) {
+        setShowCompanyDropdown(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const updateQuestion = (key: string, patch: Partial<QuestionDraft>) => {
+    setQuestions((prev) => prev.map((q) => (q.key === key ? { ...q, ...patch } : q)));
+  };
+
+  const updateOption = (key: string, opt: 'A' | 'B' | 'C' | 'D', value: string) => {
+    setQuestions((prev) => prev.map((q) => (q.key === key ? { ...q, options: { ...q.options, [opt]: value } } : q)));
+  };
+
+  const addQuestion = () => setQuestions((prev) => [...prev, emptyQuestion()]);
+  const removeQuestion = (key: string) => setQuestions((prev) => (prev.length > 1 ? prev.filter((q) => q.key !== key) : prev));
+
+  const isNonTechnical = quizType === 'non_technical';
+
+  const validate = (): string | null => {
+    if (!companyId.trim()) return 'Pick a company.';
+    if (!role.trim()) return 'Role is required.';
+    if (!experience.trim()) return 'Experience is required.';
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i];
+      if (!q.question.trim()) return `Question ${i + 1} is missing its text.`;
+      if (!q.options.A.trim() || !q.options.B.trim() || !q.options.C.trim() || !q.options.D.trim()) {
+        return `Question ${i + 1} needs all 4 options filled in.`;
+      }
+      if (!q.topic.trim()) return `Question ${i + 1} needs a topic.`;
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const validationError = validate();
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+    setIsSaving(true);
+    try {
+      const payload = {
+        company_id: companyId.trim(),
+        role: role.trim(),
+        experience: experience.trim(),
+        quiz_type: quizType,
+        theory_questions_percentage: Number(theoryPct) || 0,
+        code_analysis_questions_percentage: isNonTechnical ? 0 : Number(codePct) || 0,
+        questions: questions.map((q) => ({
+          type: q.type,
+          question: q.question.trim(),
+          code_snippet: q.type === 'code_analysis' ? q.code_snippet : null,
+          options: q.options,
+          correct_answer: q.correct_answer,
+          topic: q.topic.trim(),
+        })),
+      };
+
+      const url = mode === 'create' ? '/api/admin/quizzes' : `/api/admin/quizzes/${encodeURIComponent(initialData!.quiz_id!)}`;
+      const method = mode === 'create' ? 'POST' : 'PATCH';
+      const res = await fetch(url, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || `Failed to ${mode === 'create' ? 'create' : 'save'} quiz`);
+        return;
+      }
+      toast({
+        title: mode === 'create' ? 'Quiz created' : 'Quiz saved',
+        description: mode === 'create' ? 'The new draft quiz was created.' : 'Your changes were saved.',
+        className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
+      });
+      onSaved(data.quiz_id || initialData?.quiz_id || '');
+    } catch {
+      setError('Something went wrong. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const typeBadgeClass = useMemo(() => ({
+    theory: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+    code_analysis: 'bg-indigo-500/15 text-indigo-300 border-indigo-500/30',
+    practical_scenario: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+  }), []);
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <div className="rounded-lg border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-300">{error}</div>
+      )}
+
+      <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-5 space-y-4">
+        <h2 className="text-sm font-medium text-zinc-300">Quiz details</h2>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="relative" ref={companyBoxRef}>
+            <label className="text-xs text-zinc-500 mb-1 block">Company</label>
+            <input
+              value={companyQuery}
+              onChange={(e) => {
+                setCompanyQuery(e.target.value);
+                setCompanyId('');
+                setShowCompanyDropdown(true);
+              }}
+              onFocus={() => setShowCompanyDropdown(true)}
+              placeholder="Search company by name or id..."
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+            {showCompanyDropdown && companyOptions.length > 0 && (
+              <div className="absolute z-30 mt-1 w-full max-h-56 overflow-y-auto rounded-lg border border-zinc-700 bg-zinc-900 shadow-xl">
+                {companyOptions.map((c) => (
+                  <button
+                    type="button"
+                    key={c.company_id}
+                    onClick={() => {
+                      setCompanyId(c.company_id);
+                      setCompanyQuery(c.name);
+                      setShowCompanyDropdown(false);
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-white hover:bg-zinc-800"
+                  >
+                    {c.name} <span className="text-zinc-500 text-xs">{c.company_id}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+            {companyId && <p className="text-xs text-green-400 mt-1">Selected: {companyId}</p>}
+          </div>
+          <div>
+            <label className="text-xs text-zinc-500 mb-1 block">Role</label>
+            <input
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              placeholder="e.g. Backend Engineer"
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-zinc-500 mb-1 block">Experience</label>
+            <input
+              value={experience}
+              onChange={(e) => setExperience(e.target.value)}
+              placeholder="e.g. 2-4 years"
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-zinc-500 mb-1 block">Quiz type</label>
+            <select
+              value={quizType}
+              onChange={(e) => setQuizType(e.target.value)}
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            >
+              <option value="technical">Technical</option>
+              <option value="non_technical">Non-Technical</option>
+            </select>
+          </div>
+          <div>
+            <label className="text-xs text-zinc-500 mb-1 block">Theory %</label>
+            <input
+              type="number"
+              min={0}
+              max={100}
+              value={theoryPct}
+              onChange={(e) => setTheoryPct(Number(e.target.value))}
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+          </div>
+          {!isNonTechnical && (
+            <div>
+              <label className="text-xs text-zinc-500 mb-1 block">Code analysis %</label>
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={codePct}
+                onChange={(e) => setCodePct(Number(e.target.value))}
+                className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-green-500/40"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-zinc-300">Questions ({questions.length})</h2>
+          <button
+            type="button"
+            onClick={addQuestion}
+            className="flex items-center gap-1.5 rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-900 text-sm px-3 py-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" /> Add question
+          </button>
+        </div>
+
+        {questions.map((q, idx) => (
+          <div key={q.key} className="bg-zinc-950 border border-zinc-800 rounded-xl p-5 space-y-3">
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-zinc-500">Q{idx + 1}</span>
+              <div className="flex items-center gap-2">
+                <div className="relative">
+                  <select
+                    value={q.type}
+                    onChange={(e) => updateQuestion(q.key, { type: e.target.value as QuestionType })}
+                    className={`appearance-none text-xs rounded-full pl-2.5 pr-6 py-0.5 border bg-transparent ${typeBadgeClass[q.type]}`}
+                  >
+                    <option value="theory" className="bg-zinc-900 text-white">Theory</option>
+                    <option value="code_analysis" className="bg-zinc-900 text-white">Code analysis</option>
+                    <option value="practical_scenario" className="bg-zinc-900 text-white">Practical scenario</option>
+                  </select>
+                  <ChevronDown className="h-3 w-3 absolute right-1.5 top-1.5 pointer-events-none opacity-70" />
+                </div>
+                <button type="button" onClick={() => removeQuestion(q.key)} className="text-zinc-500 hover:text-red-400">
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+            </div>
+
+            <textarea
+              value={q.question}
+              onChange={(e) => updateQuestion(q.key, { question: e.target.value })}
+              placeholder="Question text"
+              rows={2}
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+
+            {q.type === 'code_analysis' && (
+              <textarea
+                value={q.code_snippet}
+                onChange={(e) => updateQuestion(q.key, { code_snippet: e.target.value })}
+                placeholder="Code snippet (optional)"
+                rows={3}
+                className="w-full rounded-lg bg-black border border-zinc-800 px-3 py-2 text-zinc-300 text-xs font-mono placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+              />
+            )}
+
+            <div className="grid grid-cols-2 gap-2">
+              {(['A', 'B', 'C', 'D'] as const).map((opt) => (
+                <div key={opt} className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => updateQuestion(q.key, { correct_answer: opt })}
+                    title="Mark as correct answer"
+                    className={`flex-shrink-0 w-6 h-6 rounded-full border text-xs font-medium transition-colors ${
+                      q.correct_answer === opt
+                        ? 'bg-green-500/20 border-green-500/50 text-green-300'
+                        : 'border-zinc-700 text-zinc-500 hover:border-zinc-500'
+                    }`}
+                  >
+                    {opt}
+                  </button>
+                  <input
+                    value={q.options[opt]}
+                    onChange={(e) => updateOption(q.key, opt, e.target.value)}
+                    placeholder={`Option ${opt}`}
+                    className="flex-1 rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+                  />
+                </div>
+              ))}
+            </div>
+            <p className="text-xs text-zinc-500">Click a letter to mark it as the correct answer.</p>
+
+            <input
+              value={q.topic}
+              onChange={(e) => updateQuestion(q.key, { topic: e.target.value })}
+              placeholder="Topic (e.g. React Hooks)"
+              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className="flex justify-end gap-3">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSaving}
+            className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={isSaving}
+          className="px-5 py-2 text-sm rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white font-medium disabled:opacity-60"
+        >
+          {isSaving ? 'Saving...' : mode === 'create' ? 'Create quiz' : 'Save changes'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default QuizForm;

--- a/src/app/admin/(protected)/quizzes/[quizId]/page.tsx
+++ b/src/app/admin/(protected)/quizzes/[quizId]/page.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, Users, Trophy, TrendingUp, ExternalLink } from 'lucide-react';
+import { ArrowLeft, Users, Trophy, TrendingUp, ExternalLink, Pencil } from 'lucide-react';
+import { QuizForm } from '../QuizForm';
 
 interface Option {
   A: string; B: string; C: string; D: string;
@@ -64,25 +65,26 @@ export default function AdminQuizDetailPage() {
   const [stats, setStats] = useState<Stats | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
 
-  useEffect(() => {
+  const load = async () => {
     if (!quizId) return;
-    (async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch(`/api/admin/quizzes/${encodeURIComponent(quizId)}`);
-        const data = await res.json();
-        if (!res.ok) {
-          setError(data.error || 'Failed to load quiz');
-          return;
-        }
-        setQuiz(data.quiz);
-        setStats(data.stats);
-      } finally {
-        setIsLoading(false);
+    setIsLoading(true);
+    try {
+      const res = await fetch(`/api/admin/quizzes/${encodeURIComponent(quizId)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || 'Failed to load quiz');
+        return;
       }
-    })();
-  }, [quizId]);
+      setQuiz(data.quiz);
+      setStats(data.stats);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => { load(); }, [quizId]);
 
   if (isLoading) return <div className="p-8 text-zinc-500">Loading...</div>;
   if (error || !quiz) {
@@ -95,6 +97,37 @@ export default function AdminQuizDetailPage() {
   }
 
   const questions = Array.isArray(quiz.quiz) ? quiz.quiz : [];
+
+  if (isEditing) {
+    return (
+      <div className="p-8 max-w-4xl mx-auto">
+        <Link href="/admin/quizzes" className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white mb-6">
+          <ArrowLeft className="h-4 w-4" /> Back to quizzes
+        </Link>
+        <h1 className="text-2xl font-semibold text-white mb-1">Edit quiz</h1>
+        <p className="text-sm text-zinc-500 mb-6">{quiz.quiz_id}</p>
+        <QuizForm
+          mode="edit"
+          initialData={{
+            quiz_id: quiz.quiz_id,
+            company_id: quiz.company_id,
+            company_name: quiz.company_name,
+            role: quiz.role,
+            experience: quiz.experience,
+            quiz_type: quiz.quiz_type,
+            theory_questions_percentage: quiz.theory_questions_percentage,
+            code_analysis_questions_percentage: quiz.code_analysis_questions_percentage,
+            quiz: questions,
+          }}
+          onCancel={() => setIsEditing(false)}
+          onSaved={async () => {
+            setIsEditing(false);
+            await load();
+          }}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="p-8 max-w-4xl mx-auto">
@@ -118,6 +151,12 @@ export default function AdminQuizDetailPage() {
           ) : (
             <span className="text-xs rounded-full px-2.5 py-1 bg-zinc-500/15 text-zinc-400 border border-zinc-500/30">Draft</span>
           )}
+          <button
+            onClick={() => setIsEditing(true)}
+            className="flex items-center gap-1.5 text-xs rounded-full px-2.5 py-1 border border-zinc-700 text-zinc-300 hover:bg-zinc-900"
+          >
+            <Pencil className="h-3 w-3" /> Edit
+          </button>
         </div>
       </div>
 

--- a/src/app/admin/(protected)/quizzes/new/page.tsx
+++ b/src/app/admin/(protected)/quizzes/new/page.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { QuizForm } from '../QuizForm';
+
+export default function NewQuizPage() {
+  const router = useRouter();
+
+  return (
+    <div className="p-8 max-w-4xl mx-auto">
+      <Link href="/admin/quizzes" className="inline-flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white mb-6">
+        <ArrowLeft className="h-4 w-4" /> Back to quizzes
+      </Link>
+      <h1 className="text-2xl font-semibold text-white mb-1">New quiz</h1>
+      <p className="text-sm text-zinc-500 mb-6">Manually create a generated (draft) quiz. It won&apos;t be publicly reachable until it&apos;s published through the normal publish flow.</p>
+
+      <QuizForm
+        mode="create"
+        onSaved={(quizId) => router.push(`/admin/quizzes/${encodeURIComponent(quizId)}`)}
+      />
+    </div>
+  );
+}

--- a/src/app/admin/(protected)/quizzes/page.tsx
+++ b/src/app/admin/(protected)/quizzes/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Trash2, Users, ChevronRight } from 'lucide-react';
+import { Trash2, Users, ChevronRight, Plus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
+
+type StatusFilter = 'all' | 'draft' | 'published';
 
 interface QuizRow {
   quiz_id: string;
@@ -26,6 +28,7 @@ export default function AdminQuizzesPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [deleteTarget, setDeleteTarget] = useState<QuizRow | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
 
   const load = async () => {
     setIsLoading(true);
@@ -39,6 +42,18 @@ export default function AdminQuizzesPage() {
   };
 
   useEffect(() => { load(); }, []);
+
+  const counts = useMemo(() => ({
+    all: quizzes.length,
+    draft: quizzes.filter((q) => !q.quiz_public_link).length,
+    published: quizzes.filter((q) => !!q.quiz_public_link).length,
+  }), [quizzes]);
+
+  const visibleQuizzes = useMemo(() => {
+    if (statusFilter === 'draft') return quizzes.filter((q) => !q.quiz_public_link);
+    if (statusFilter === 'published') return quizzes.filter((q) => !!q.quiz_public_link);
+    return quizzes;
+  }, [quizzes, statusFilter]);
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -62,10 +77,40 @@ export default function AdminQuizzesPage() {
     }
   };
 
+  const tabs: { key: StatusFilter; label: string }[] = [
+    { key: 'all', label: `All (${counts.all})` },
+    { key: 'draft', label: `Generated / Draft (${counts.draft})` },
+    { key: 'published', label: `Published (${counts.published})` },
+  ];
+
   return (
     <div className="p-8 max-w-7xl mx-auto">
-      <h1 className="text-2xl font-semibold text-white mb-1">Quizzes</h1>
-      <p className="text-sm text-zinc-500 mb-6">{quizzes.length} quizzes shown (most recent 300) — click a row to view its questions</p>
+      <div className="flex items-start justify-between mb-1">
+        <h1 className="text-2xl font-semibold text-white">Quizzes</h1>
+        <Link
+          href="/admin/quizzes/new"
+          className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white text-sm font-medium px-4 py-2"
+        >
+          <Plus className="h-4 w-4" /> New Quiz
+        </Link>
+      </div>
+      <p className="text-sm text-zinc-500 mb-5">{visibleQuizzes.length} of {quizzes.length} quizzes shown (most recent 300) — click a row to view its questions</p>
+
+      <div className="flex items-center gap-1.5 mb-5 border border-zinc-800 rounded-lg p-1 w-fit bg-zinc-950">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setStatusFilter(tab.key)}
+            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+              statusFilter === tab.key
+                ? 'bg-gradient-to-r from-green-600/20 to-blue-600/20 text-white border border-green-500/30'
+                : 'text-zinc-400 hover:text-white hover:bg-zinc-900 border border-transparent'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
 
       <div className="border border-zinc-800 rounded-xl overflow-hidden">
         <table className="w-full text-sm">
@@ -85,9 +130,9 @@ export default function AdminQuizzesPage() {
           <tbody className="divide-y divide-zinc-900">
             {isLoading ? (
               <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
-            ) : quizzes.length === 0 ? (
+            ) : visibleQuizzes.length === 0 ? (
               <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">No quizzes found</td></tr>
-            ) : quizzes.map((q) => (
+            ) : visibleQuizzes.map((q) => (
               <tr key={q.quiz_id} className="hover:bg-zinc-900/60 relative">
                 <td className="px-4 py-3 text-white">
                   <Link href={`/admin/quizzes/${encodeURIComponent(q.quiz_id)}`} className="absolute inset-0 z-10" aria-label={`View ${q.role} quiz`} />

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -2,12 +2,13 @@
 
 import { useState, FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
-import { Lock } from 'lucide-react';
+import { Lock, Eye, EyeOff } from 'lucide-react';
 
 export default function AdminLoginPage() {
   const router = useRouter();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -66,15 +67,25 @@ export default function AdminLoginPage() {
           </div>
           <div className="space-y-1.5">
             <label className="text-sm text-zinc-300">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete="current-password"
-              required
-              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/50"
-              placeholder="Password"
-            />
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="current-password"
+                required
+                className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 pr-10 text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/50"
+                placeholder="Password"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                tabIndex={-1}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-zinc-500 hover:text-zinc-300 transition-colors"
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
           </div>
           <button
             type="submit"

--- a/src/app/api/admin/quizzes/[quizId]/route.ts
+++ b/src/app/api/admin/quizzes/[quizId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminSession } from '@/lib/adminSession';
 import { getAdminDb } from '@/lib/adminDb';
+import { validateQuizPayload, buildQuizContent } from '@/lib/adminQuizValidation';
 
 export async function GET(request: NextRequest, { params }: { params: Promise<{ quizId: string }> }) {
   if (!requireAdminSession(request)) {
@@ -57,5 +58,49 @@ export async function GET(request: NextRequest, { params }: { params: Promise<{ 
     });
   } catch (error: any) {
     return NextResponse.json({ error: error.message || 'Failed to fetch quiz' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: NextRequest, { params }: { params: Promise<{ quizId: string }> }) {
+  if (!requireAdminSession(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { quizId } = await params;
+
+  try {
+    const body = await request.json();
+    const validationError = validateQuizPayload(body);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    const quizContent = buildQuizContent(body.questions);
+    const db = getAdminDb();
+    const result = await db.query(
+      `UPDATE generated_quizzes
+       SET company_id = $1, role = $2, experience = $3, quiz_type = $4,
+           theory_questions_percentage = $5, code_analysis_questions_percentage = $6,
+           num_questions = $7, quiz = $8
+       WHERE quiz_id = $9 AND is_deleted = false`,
+      [
+        body.company_id,
+        body.role,
+        body.experience,
+        body.quiz_type,
+        Number(body.theory_questions_percentage) || 0,
+        Number(body.code_analysis_questions_percentage) || 0,
+        quizContent.length,
+        JSON.stringify(quizContent),
+        quizId,
+      ]
+    );
+
+    if (result.rowCount === 0) {
+      return NextResponse.json({ error: 'Quiz not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true, quiz_id: quizId });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to save quiz' }, { status: 500 });
   }
 }

--- a/src/app/api/admin/quizzes/route.ts
+++ b/src/app/api/admin/quizzes/route.ts
@@ -1,6 +1,8 @@
+import crypto from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminSession } from '@/lib/adminSession';
 import { getAdminDb } from '@/lib/adminDb';
+import { validateQuizPayload, buildQuizContent } from '@/lib/adminQuizValidation';
 
 export async function GET(request: NextRequest) {
   if (!requireAdminSession(request)) {
@@ -26,6 +28,46 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ quizzes: result.rows });
   } catch (error: any) {
     return NextResponse.json({ error: error.message || 'Failed to fetch quizzes' }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  if (!requireAdminSession(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  try {
+    const body = await request.json();
+    const validationError = validateQuizPayload(body);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
+    }
+
+    const quizId = crypto.randomUUID();
+    const quizContent = buildQuizContent(body.questions);
+
+    const db = getAdminDb();
+    await db.query(
+      `INSERT INTO generated_quizzes
+        (quiz_id, company_id, role, experience, num_questions, quiz_type,
+         theory_questions_percentage, code_analysis_questions_percentage,
+         quiz, is_publish, is_deleted, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, false, false, NOW())`,
+      [
+        quizId,
+        body.company_id,
+        body.role,
+        body.experience,
+        quizContent.length,
+        body.quiz_type,
+        Number(body.theory_questions_percentage) || 0,
+        Number(body.code_analysis_questions_percentage) || 0,
+        JSON.stringify(quizContent),
+      ]
+    );
+
+    return NextResponse.json({ success: true, quiz_id: quizId });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to create quiz' }, { status: 500 });
   }
 }
 

--- a/src/app/api/admin/send-email/route.ts
+++ b/src/app/api/admin/send-email/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdminSession } from '@/lib/adminSession';
+
+const SUPPORT_SENDER_EMAIL = 'support@quizzviz.com';
+
+export async function POST(request: NextRequest) {
+  if (!requireAdminSession(request)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const { recipient_email, subject, message } = await request.json();
+
+    if (!recipient_email || typeof recipient_email !== 'string' || !recipient_email.includes('@')) {
+      return NextResponse.json({ error: 'A valid recipient email is required' }, { status: 400 });
+    }
+    if (!subject || typeof subject !== 'string' || !subject.trim()) {
+      return NextResponse.json({ error: 'Subject is required' }, { status: 400 });
+    }
+    if (!message || typeof message !== 'string' || !message.trim()) {
+      return NextResponse.json({ error: 'Message is required' }, { status: 400 });
+    }
+
+    const response = await fetch(`${process.env.NEXT_PUBLIC_SEND_EMAILS_SERVICE_URL}/send-email`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        sender_email: SUPPORT_SENDER_EMAIL,
+        recipient_email: recipient_email.trim(),
+        subject: subject.trim().substring(0, 200),
+        message: message.trim().substring(0, 10000),
+        email_type: 'admin_notice',
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      return NextResponse.json(
+        { error: errorData.message || `Failed to send email. Status: ${response.status}` },
+        { status: 502 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error: any) {
+    return NextResponse.json({ error: error.message || 'Failed to send email' }, { status: 500 });
+  }
+}

--- a/src/lib/adminQuizValidation.ts
+++ b/src/lib/adminQuizValidation.ts
@@ -1,0 +1,30 @@
+const VALID_OPTION_KEYS = ['A', 'B', 'C', 'D'] as const;
+
+export function validateQuizPayload(body: any): string | null {
+  if (!body.company_id || typeof body.company_id !== 'string') return 'company_id is required';
+  if (!body.role || typeof body.role !== 'string') return 'role is required';
+  if (!body.experience || typeof body.experience !== 'string') return 'experience is required';
+  if (body.quiz_type !== 'technical' && body.quiz_type !== 'non_technical') return 'quiz_type must be technical or non_technical';
+  if (!Array.isArray(body.questions) || body.questions.length === 0) return 'At least one question is required';
+  for (const q of body.questions) {
+    if (!q.question || typeof q.question !== 'string') return 'Every question needs question text';
+    if (!q.options || VALID_OPTION_KEYS.some((k) => !q.options[k] || typeof q.options[k] !== 'string')) {
+      return 'Every question needs all 4 options (A-D)';
+    }
+    if (!VALID_OPTION_KEYS.includes(q.correct_answer)) return 'Every question needs a valid correct_answer (A-D)';
+    if (!q.topic || typeof q.topic !== 'string') return 'Every question needs a topic';
+  }
+  return null;
+}
+
+export function buildQuizContent(questions: any[]) {
+  return questions.map((q, idx) => ({
+    id: idx + 1,
+    type: q.type || 'theory',
+    question: q.question,
+    code_snippet: q.code_snippet || null,
+    options: q.options,
+    correct_answer: q.correct_answer,
+    topic: q.topic,
+  }));
+}


### PR DESCRIPTION
- Add All/Generated (Draft)/Published filter tabs to the Quizzes list so unpublished quizzes are clearly visible, not just published ones
- Add manual quiz creation (/admin/quizzes/new) and an in-place quiz editor, both built on a shared QuizForm (company picker + question builder with options, correct-answer picker, topic, optional code snippet)
- Add POST/PATCH endpoints for generated_quizzes with shared payload validation in src/lib/adminQuizValidation.ts
- Add a new "Email Customers" tab: search-as-you-type recipient picker (companies + users), subject/message compose, and a review-before-send confirmation modal, backed by a new /api/admin/send-email route that reuses the existing outbound mail microservice
- Resize the admin sidebar logo/brand text to match the Dashboard's sizing and link it to "/" instead of "/admin"
- Add a show/hide eye icon toggle to the admin login password field