### PR TITLE
fix: admin panel bugs and elite UX pass

### DIFF
--- a/src/app/admin/(protected)/AdminNav.tsx
+++ b/src/app/admin/(protected)/AdminNav.tsx
@@ -3,14 +3,14 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { LayoutDashboard, Building2, Users, BarChart3, FileQuestion, ClipboardList, LogOut, Gauge, Mail } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { LayoutDashboard, Building2, BarChart3, FileQuestion, ClipboardList, LogOut, Gauge, Mail } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const NAV_ITEMS = [
   { href: '/admin', label: 'Overview', icon: LayoutDashboard },
   { href: '/admin/companies', label: 'Companies & Billing', icon: Building2 },
   { href: '/admin/usage', label: 'Usage', icon: Gauge },
-  { href: '/admin/users', label: 'Users', icon: Users },
   { href: '/admin/analytics', label: 'Growth Analytics', icon: BarChart3 },
   { href: '/admin/quizzes', label: 'Quizzes', icon: FileQuestion },
   { href: '/admin/results', label: 'Attempts / Results', icon: ClipboardList },
@@ -31,7 +31,7 @@ export default function AdminNav() {
     <aside className="w-64 flex-shrink-0 border-r border-zinc-800 bg-zinc-950 flex flex-col">
       <div className="px-5 py-5 border-b border-zinc-800">
         <Link href="/" className="flex items-center gap-2 group">
-          <div className="relative h-10 w-10 flex-shrink-0">
+          <div className="relative h-10 w-10 flex-shrink-0 transition-transform duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] group-hover:scale-105">
             <Image
               src="/QuizzViz-logo.png"
               alt="QuizzViz Logo"
@@ -53,14 +53,19 @@ export default function AdminNav() {
               key={href}
               href={href}
               className={cn(
-                'flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-colors',
-                active
-                  ? 'bg-gradient-to-r from-green-600/20 to-blue-600/20 text-white border border-green-500/30'
-                  : 'text-zinc-400 hover:text-white hover:bg-zinc-900'
+                'relative flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] transform hover:scale-[1.02] active:scale-[0.98] will-change-transform',
+                active ? 'text-white' : 'text-zinc-400 hover:text-white hover:bg-zinc-900'
               )}
             >
-              <Icon className="h-4 w-4" />
-              {label}
+              {active && (
+                <motion.span
+                  layoutId="admin-nav-active"
+                  className="absolute inset-0 rounded-lg bg-gradient-to-r from-green-600/20 to-blue-600/20 border border-green-500/30"
+                  transition={{ type: 'spring', stiffness: 380, damping: 32 }}
+                />
+              )}
+              <Icon className="h-4 w-4 relative z-10" />
+              <span className="relative z-10">{label}</span>
             </Link>
           );
         })}
@@ -68,7 +73,7 @@ export default function AdminNav() {
       <div className="p-3 border-t border-zinc-800">
         <button
           onClick={handleLogout}
-          className="w-full flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-zinc-400 hover:text-red-400 hover:bg-red-500/10 transition-colors"
+          className="w-full flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-zinc-400 hover:text-red-400 hover:bg-red-500/10 transition-all duration-300 ease-[cubic-bezier(0.16,1,0.3,1)] hover:scale-[1.02] active:scale-[0.98]"
         >
           <LogOut className="h-4 w-4" />
           Sign Out

--- a/src/app/admin/(protected)/AdminPageLoading.tsx
+++ b/src/app/admin/(protected)/AdminPageLoading.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+export function AdminPageLoading({ text = 'Loading...', size = 'md' }: { text?: string; size?: 'sm' | 'md' }) {
+  const ring = size === 'sm' ? 'w-8 h-8 border-2' : 'w-12 h-12 border-[3px]';
+  return (
+    <div className="flex items-center justify-center py-16">
+      <div className="flex flex-col items-center space-y-3">
+        <div className="relative">
+          <div className={`${ring} border-zinc-800 rounded-full`} />
+          <div className={`${ring} border-transparent rounded-full border-t-green-400 border-r-blue-400 animate-spin absolute top-0 left-0`} />
+        </div>
+        <p className="text-sm bg-gradient-to-r from-green-400 to-blue-500 bg-clip-text text-transparent font-medium">
+          {text}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function AdminErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-5 py-6 text-center">
+      <p className="text-sm text-red-300 mb-3">{message}</p>
+      <button
+        onClick={onRetry}
+        className="text-sm rounded-lg border border-red-500/30 text-red-300 hover:bg-red-500/10 px-4 py-1.5 transition-colors"
+      >
+        Retry
+      </button>
+    </div>
+  );
+}
+
+export default AdminPageLoading;

--- a/src/app/admin/(protected)/AdminPageTransition.tsx
+++ b/src/app/admin/(protected)/AdminPageTransition.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { motion, AnimatePresence } from 'framer-motion';
+
+export function AdminPageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+
+  return (
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -8 }}
+        transition={{ duration: 0.25, ease: [0.16, 1, 0.3, 1] }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+export default AdminPageTransition;

--- a/src/app/admin/(protected)/analytics/page.tsx
+++ b/src/app/admin/(protected)/analytics/page.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
 import {
   ResponsiveContainer, LineChart, Line, BarChart, Bar, XAxis, YAxis,
   CartesianGrid, Tooltip, Legend,
 } from 'recharts';
 import { TrendingUp, TrendingDown, Building2, FileQuestion, Send, ClipboardCheck } from 'lucide-react';
+import { useAdminData } from '../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
 
 interface MonthlyPoint {
   year: number;
@@ -47,31 +50,36 @@ function StatCard({ label, value, icon: Icon, deltaPct }: { label: string; value
   );
 }
 
+interface AnalyticsPayload {
+  monthly: MonthlyPoint[];
+  yearly: YearlyPoint[];
+  totals: any;
+}
+
 export default function AdminAnalyticsPage() {
-  const [monthly, setMonthly] = useState<MonthlyPoint[]>([]);
-  const [yearly, setYearly] = useState<YearlyPoint[]>([]);
-  const [totals, setTotals] = useState<any>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<AnalyticsPayload>('admin-analytics', async () => {
+    const res = await fetch('/api/admin/analytics');
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `Failed to load analytics (${res.status})`);
+    }
+    const json = await res.json();
+    return { monthly: json.monthly || [], yearly: json.yearly || [], totals: json.totals || null };
+  });
+
+  const monthly = data?.monthly || [];
+  const yearly = data?.yearly || [];
+  const totals = data?.totals || null;
+
   const [selectedYear, setSelectedYear] = useState<number | null>(null);
   const [compareWithPreviousYear, setCompareWithPreviousYear] = useState(true);
 
   useEffect(() => {
-    (async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch('/api/admin/analytics');
-        const data = await res.json();
-        setMonthly(data.monthly || []);
-        setYearly(data.yearly || []);
-        setTotals(data.totals || null);
-        if (data.yearly?.length) {
-          setSelectedYear(data.yearly[data.yearly.length - 1].year);
-        }
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, []);
+    if (selectedYear === null && yearly.length) {
+      setSelectedYear(yearly[yearly.length - 1].year);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [yearly]);
 
   const availableYears = useMemo(() => yearly.map((y) => y.year), [yearly]);
 
@@ -99,12 +107,29 @@ export default function AdminAnalyticsPage() {
   }, [monthly]);
 
   if (isLoading) {
-    return <div className="p-8 text-zinc-500">Loading analytics...</div>;
+    return <AdminPageLoading text="Loading analytics..." />;
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 max-w-2xl mx-auto">
+        <AdminErrorState message={error} onRetry={refresh} />
+      </div>
+    );
   }
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
-      <h1 className="text-2xl font-semibold text-white mb-1">Growth Analytics</h1>
+      <div className="flex items-start justify-between mb-1">
+        <h1 className="text-2xl font-semibold text-white">Growth Analytics</h1>
+        <button
+          onClick={refresh}
+          disabled={isRefreshing}
+          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
+        </button>
+      </div>
       <p className="text-sm text-zinc-500 mb-6">QuizzViz platform growth — quiz generation, publishing, and attempts over time.</p>
 
       <div className="grid grid-cols-4 gap-4 mb-8">

--- a/src/app/admin/(protected)/companies/[companyId]/page.tsx
+++ b/src/app/admin/(protected)/companies/[companyId]/page.tsx
@@ -7,6 +7,8 @@ import { ArrowLeft, Trash2, Save } from 'lucide-react';
 import { computePeriodEnd } from '@/lib/billingCycle';
 import { useToast } from '@/hooks/use-toast';
 import { ConfirmDeleteModal } from '../../ConfirmDeleteModal';
+import { useAdminData, invalidateAdminData } from '../../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../../AdminPageLoading';
 
 interface CustomLimits {
   maxQuizzes?: number;
@@ -44,26 +46,25 @@ export default function AdminCompanyDetailPage() {
   const companyId = params?.companyId as string;
   const { toast } = useToast();
 
+  const cacheKey = `admin-company-${companyId || 'unknown'}`;
+  const { data: fetchedCompany, isLoading, error: loadError, refresh, setData: setCachedCompany } = useAdminData<Company>(cacheKey, async () => {
+    if (!companyId) throw new Error('Missing company id');
+    const res = await fetch(`/api/admin/companies/${encodeURIComponent(companyId)}`);
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `Failed to load company (${res.status})`);
+    }
+    const json = await res.json();
+    return json.company;
+  });
+
   const [company, setCompany] = useState<Company | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  const load = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch(`/api/admin/companies/${encodeURIComponent(companyId)}`);
-      const data = await res.json();
-      if (res.ok) setCompany(data.company);
-      else setMessage({ type: 'error', text: data.error || 'Failed to load company' });
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => { if (companyId) load(); }, [companyId]);
+  useEffect(() => { if (fetchedCompany) setCompany(fetchedCompany); }, [fetchedCompany]);
 
   const update = (patch: Partial<Company>) => setCompany((prev) => prev ? { ...prev, ...patch } : prev);
   const updateLimits = (patch: Partial<CustomLimits>) =>
@@ -138,6 +139,9 @@ export default function AdminCompanyDetailPage() {
         return;
       }
       setCompany(data.company);
+      setCachedCompany(data.company);
+      invalidateAdminData('admin-companies');
+      invalidateAdminData('admin-overview');
       setMessage({ type: 'success', text: 'Saved successfully.' });
       toast({
         title: 'Saved',
@@ -155,6 +159,9 @@ export default function AdminCompanyDetailPage() {
     try {
       const res = await fetch(`/api/admin/companies/${encodeURIComponent(companyId)}`, { method: 'DELETE' });
       if (res.ok) {
+        invalidateAdminData(cacheKey);
+        invalidateAdminData('admin-companies');
+        invalidateAdminData('admin-overview');
         toast({
           title: 'Company deleted',
           description: `${company.name} was permanently removed.`,
@@ -172,14 +179,18 @@ export default function AdminCompanyDetailPage() {
   };
 
   if (isLoading) {
-    return <div className="p-8 text-zinc-500">Loading...</div>;
+    return <AdminPageLoading text="Loading company..." />;
   }
 
   if (!company) {
     return (
-      <div className="p-8">
-        <p className="text-red-400">{message?.text || 'Company not found.'}</p>
-        <Link href="/admin/companies" className="text-green-400 text-sm mt-2 inline-block">Back to companies</Link>
+      <div className="p-8 max-w-2xl mx-auto">
+        {loadError ? (
+          <AdminErrorState message={loadError} onRetry={refresh} />
+        ) : (
+          <p className="text-red-400">{message?.text || 'Company not found.'}</p>
+        )}
+        <Link href="/admin/companies" className="text-green-400 text-sm mt-3 inline-block">Back to companies</Link>
       </div>
     );
   }

--- a/src/app/admin/(protected)/companies/page.tsx
+++ b/src/app/admin/(protected)/companies/page.tsx
@@ -2,7 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Search, ChevronRight } from 'lucide-react';
+import { Search, ChevronRight, RefreshCw } from 'lucide-react';
+import { useAdminData } from '../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
 
 interface Company {
   company_id: string;
@@ -36,28 +38,36 @@ function expiryStatus(expiry: string | null): { label: string; className: string
 }
 
 export default function AdminCompaniesPage() {
-  const [companies, setCompanies] = useState<Company[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [search, setSearch] = useState('');
-
-  const load = async (q: string) => {
-    setIsLoading(true);
-    try {
-      const res = await fetch(`/api/admin/companies${q ? `?q=${encodeURIComponent(q)}` : ''}`);
-      const data = await res.json();
-      setCompanies(data.companies || []);
-    } finally {
-      setIsLoading(false);
+  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<Company[]>('admin-companies', async () => {
+    const res = await fetch('/api/admin/companies');
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `Failed to load companies (${res.status})`);
     }
-  };
+    const json = await res.json();
+    return json.companies || [];
+  });
 
-  useEffect(() => { load(''); }, []);
+  const [search, setSearch] = useState('');
+  const [searchResults, setSearchResults] = useState<Company[] | null>(null);
+  const [isSearching, setIsSearching] = useState(false);
 
   useEffect(() => {
-    const t = setTimeout(() => load(search), 350);
+    if (!search) { setSearchResults(null); return; }
+    setIsSearching(true);
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(`/api/admin/companies?q=${encodeURIComponent(search)}`);
+        const json = await res.json();
+        setSearchResults(json.companies || []);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 350);
     return () => clearTimeout(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
+
+  const companies = searchResults ?? data ?? [];
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
@@ -66,7 +76,16 @@ export default function AdminCompaniesPage() {
           <h1 className="text-2xl font-semibold text-white">Companies & Billing</h1>
           <p className="text-sm text-zinc-500 mt-1">{companies.length} companies shown</p>
         </div>
+        <button
+          onClick={refresh}
+          disabled={isRefreshing}
+          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
+        </button>
       </div>
+
+      {error && <div className="mb-5"><AdminErrorState message={error} onRetry={refresh} /></div>}
 
       <div className="relative mb-5 max-w-md">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
@@ -91,8 +110,8 @@ export default function AdminCompaniesPage() {
             </tr>
           </thead>
           <tbody className="divide-y divide-zinc-900">
-            {isLoading ? (
-              <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
+            {isLoading || isSearching ? (
+              <tr><td colSpan={6} className="p-0"><AdminPageLoading /></td></tr>
             ) : companies.length === 0 ? (
               <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">No companies found</td></tr>
             ) : companies.map((c) => {

--- a/src/app/admin/(protected)/email/page.tsx
+++ b/src/app/admin/(protected)/email/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Mail, Search, Send, X } from 'lucide-react';
+import { Mail, Search, Send, X, CheckCircle } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
 import { useToast } from '@/hooks/use-toast';
 
 interface Suggestion {
@@ -11,28 +12,36 @@ interface Suggestion {
   sublabel: string;
 }
 
+interface Recipient {
+  email: string;
+  label: string;
+}
+
+type SendState = 'idle' | 'sending' | 'sent';
+
 export default function AdminEmailPage() {
   const { toast } = useToast();
-  const [recipient, setRecipient] = useState('');
+  const [recipients, setRecipients] = useState<Recipient[]>([]);
+  const [recipientInput, setRecipientInput] = useState('');
   const [subject, setSubject] = useState('');
   const [message, setMessage] = useState('');
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [showSuggestions, setShowSuggestions] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
-  const [isSending, setIsSending] = useState(false);
+  const [sendState, setSendState] = useState<SendState>('idle');
   const [error, setError] = useState<string | null>(null);
   const boxRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!recipient || recipient.includes('@')) {
+    if (!recipientInput) {
       setSuggestions([]);
       return;
     }
     const t = setTimeout(async () => {
       try {
         const [companiesRes, usersRes] = await Promise.all([
-          fetch(`/api/admin/companies?q=${encodeURIComponent(recipient)}`),
-          fetch(`/api/admin/users?q=${encodeURIComponent(recipient)}`),
+          fetch(`/api/admin/companies?q=${encodeURIComponent(recipientInput)}`),
+          fetch(`/api/admin/users?q=${encodeURIComponent(recipientInput)}`),
         ]);
         const companies = await companiesRes.json();
         const users = await usersRes.json();
@@ -55,7 +64,7 @@ export default function AdminEmailPage() {
       }
     }, 300);
     return () => clearTimeout(t);
-  }, [recipient]);
+  }, [recipientInput]);
 
   useEffect(() => {
     const handleClick = (e: MouseEvent) => {
@@ -67,8 +76,27 @@ export default function AdminEmailPage() {
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
 
+  const addRecipient = (recipient: Recipient) => {
+    setRecipients((prev) => (prev.some((r) => r.email === recipient.email) ? prev : [...prev, recipient]));
+    setRecipientInput('');
+    setSuggestions([]);
+    setShowSuggestions(false);
+  };
+
+  const removeRecipient = (email: string) => setRecipients((prev) => prev.filter((r) => r.email !== email));
+
+  const handleRecipientKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' || e.key === ',') {
+      e.preventDefault();
+      const value = recipientInput.trim().replace(/,$/, '');
+      if (value && value.includes('@')) {
+        addRecipient({ email: value, label: value });
+      }
+    }
+  };
+
   const validate = (): string | null => {
-    if (!recipient.trim() || !recipient.includes('@')) return 'Enter a valid recipient email address.';
+    if (recipients.length === 0) return 'Add at least one recipient.';
     if (!subject.trim()) return 'Subject is required.';
     if (!message.trim()) return 'Message is required.';
     return null;
@@ -81,41 +109,60 @@ export default function AdminEmailPage() {
       return;
     }
     setError(null);
+    setSendState('idle');
     setShowConfirm(true);
   };
 
   const handleSend = async () => {
-    setIsSending(true);
-    try {
-      const res = await fetch('/api/admin/send-email', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recipient_email: recipient.trim(), subject: subject.trim(), message: message.trim() }),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok) {
-        toast({ title: 'Send failed', description: data.error || 'Failed to send email', variant: 'destructive' });
-        setShowConfirm(false);
-        return;
-      }
-      toast({
-        title: 'Email sent',
-        description: `Your message was sent to ${recipient.trim()}.`,
-        className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
-      });
+    setSendState('sending');
+    const results = await Promise.allSettled(
+      recipients.map((r) =>
+        fetch('/api/admin/send-email', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ recipient_email: r.email, subject: subject.trim(), message: message.trim() }),
+        }).then(async (res) => {
+          if (!res.ok) {
+            const body = await res.json().catch(() => ({}));
+            throw new Error(body.error || `Failed for ${r.email}`);
+          }
+        })
+      )
+    );
+
+    const failed = results
+      .map((r, i) => (r.status === 'rejected' ? recipients[i].email : null))
+      .filter((email): email is string => Boolean(email));
+
+    if (failed.length === recipients.length) {
+      setSendState('idle');
       setShowConfirm(false);
-      setRecipient('');
+      toast({ title: 'Send failed', description: `Failed to send to all ${failed.length} recipient(s).`, variant: 'destructive' });
+      return;
+    }
+
+    if (failed.length > 0) {
+      toast({
+        title: 'Sent with some failures',
+        description: `Sent to ${recipients.length - failed.length} of ${recipients.length}. Failed: ${failed.join(', ')}`,
+        variant: 'destructive',
+      });
+    }
+
+    setSendState('sent');
+    setTimeout(() => {
+      setShowConfirm(false);
+      setSendState('idle');
+      setRecipients([]);
       setSubject('');
       setMessage('');
-    } finally {
-      setIsSending(false);
-    }
+    }, 1500);
   };
 
   return (
     <div className="p-8 max-w-3xl mx-auto">
       <h1 className="text-2xl font-semibold text-white mb-1">Email Customers</h1>
-      <p className="text-sm text-zinc-500 mb-6">Send a one-off email directly to a company owner, user, or any address.</p>
+      <p className="text-sm text-zinc-500 mb-6">Send an email to one or many company owners, users, or any address.</p>
 
       <div className="bg-zinc-950 border border-zinc-800 rounded-xl p-6 space-y-4">
         {error && (
@@ -124,16 +171,29 @@ export default function AdminEmailPage() {
 
         <div className="relative" ref={boxRef}>
           <label className="text-xs text-zinc-500 mb-1 block">To</label>
+          {recipients.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {recipients.map((r) => (
+                <span key={r.email} className="inline-flex items-center gap-1.5 text-xs rounded-full pl-2.5 pr-1.5 py-1 bg-green-500/10 border border-green-500/30 text-green-300">
+                  {r.label !== r.email ? `${r.label} <${r.email}>` : r.email}
+                  <button type="button" onClick={() => removeRecipient(r.email)} className="hover:text-white">
+                    <X className="h-3 w-3" />
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
           <div className="relative">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
             <input
-              value={recipient}
+              value={recipientInput}
               onChange={(e) => {
-                setRecipient(e.target.value);
+                setRecipientInput(e.target.value);
                 setShowSuggestions(true);
               }}
               onFocus={() => setShowSuggestions(true)}
-              placeholder="Search by company, name, or type an email..."
+              onKeyDown={handleRecipientKeyDown}
+              placeholder="Search by company/name, or type an email and press Enter..."
               className="w-full rounded-lg bg-zinc-900 border border-zinc-700 pl-9 pr-3 py-2 text-white text-sm placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
             />
           </div>
@@ -143,10 +203,7 @@ export default function AdminEmailPage() {
                 <button
                   key={s.key}
                   type="button"
-                  onClick={() => {
-                    setRecipient(s.email);
-                    setShowSuggestions(false);
-                  }}
+                  onClick={() => addRecipient({ email: s.email, label: s.label })}
                   className="w-full text-left px-3 py-2 text-sm hover:bg-zinc-800"
                 >
                   <div className="text-white">{s.label}</div>
@@ -183,46 +240,79 @@ export default function AdminEmailPage() {
             onClick={handleReview}
             className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white text-sm font-medium px-4 py-2"
           >
-            <Send className="h-4 w-4" /> Review &amp; Send
+            <Send className="h-4 w-4" /> Review &amp; Send{recipients.length > 1 ? ` (${recipients.length})` : ''}
           </button>
         </div>
       </div>
 
       {showConfirm && (
         <div className="fixed inset-0 bg-black/70 backdrop-blur-sm flex items-center justify-center z-50 p-4">
-          <div className="bg-zinc-900 border border-green-500/20 rounded-2xl p-6 w-full max-w-lg shadow-2xl shadow-green-900/20">
-            <div className="flex items-start justify-between mb-4">
-              <div className="flex items-center gap-3">
-                <div className="flex items-center justify-center w-11 h-11 rounded-full bg-gradient-to-br from-green-500 to-blue-500 shadow-lg shadow-green-500/30 flex-shrink-0">
-                  <Mail className="h-5 w-5 text-white" />
-                </div>
-                <h3 className="text-lg font-semibold text-white leading-tight">Send this email?</h3>
-              </div>
-              <button onClick={() => setShowConfirm(false)} disabled={isSending} className="text-zinc-500 hover:text-white flex-shrink-0">
-                <X className="h-4 w-4" />
-              </button>
-            </div>
-            <div className="text-sm text-zinc-400 mb-6 space-y-2">
-              <p><span className="text-zinc-500">To:</span> <span className="text-white">{recipient}</span></p>
-              <p><span className="text-zinc-500">Subject:</span> <span className="text-white">{subject}</span></p>
-              <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-zinc-300">{message}</div>
-            </div>
-            <div className="flex justify-end gap-3">
-              <button
-                onClick={() => setShowConfirm(false)}
-                disabled={isSending}
-                className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800 disabled:opacity-50 transition-colors"
-              >
-                Edit
-              </button>
-              <button
-                onClick={handleSend}
-                disabled={isSending}
-                className="px-4 py-2 text-sm rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white font-medium disabled:opacity-60 shadow-lg shadow-green-600/20 transition-all"
-              >
-                {isSending ? 'Sending...' : 'Confirm & Send'}
-              </button>
-            </div>
+          <div className="bg-zinc-900 border border-green-500/20 rounded-2xl p-6 w-full max-w-lg shadow-2xl shadow-green-900/20 overflow-hidden">
+            <AnimatePresence mode="wait">
+              {sendState === 'sent' ? (
+                <motion.div
+                  key="sent"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  className="py-6 text-center"
+                >
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ type: 'spring', stiffness: 260, damping: 18 }}
+                    className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-gradient-to-br from-green-500 to-emerald-600 mb-4"
+                  >
+                    <CheckCircle className="w-8 h-8 text-white" />
+                  </motion.div>
+                  <h3 className="text-2xl font-semibold bg-gradient-to-r from-white via-gray-100 to-gray-300 bg-clip-text text-transparent">
+                    Sent
+                  </h3>
+                  <p className="text-sm text-zinc-400 mt-1">
+                    {recipients.length > 1 ? `Delivered to ${recipients.length} recipients.` : `Delivered to ${recipients[0]?.email}.`}
+                  </p>
+                </motion.div>
+              ) : (
+                <motion.div key="confirm" initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
+                  <div className="flex items-start justify-between mb-4">
+                    <div className="flex items-center gap-3">
+                      <div className="flex items-center justify-center w-11 h-11 rounded-full bg-gradient-to-br from-green-500 to-blue-500 shadow-lg shadow-green-500/30 flex-shrink-0">
+                        <Mail className="h-5 w-5 text-white" />
+                      </div>
+                      <h3 className="text-lg font-semibold text-white leading-tight">
+                        Send this email{recipients.length > 1 ? ` to ${recipients.length} recipients` : ''}?
+                      </h3>
+                    </div>
+                    <button onClick={() => setShowConfirm(false)} disabled={sendState === 'sending'} className="text-zinc-500 hover:text-white flex-shrink-0">
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                  <div className="text-sm text-zinc-400 mb-6 space-y-2">
+                    <div>
+                      <span className="text-zinc-500">To:</span>{' '}
+                      <span className="text-white">{recipients.map((r) => r.email).join(', ')}</span>
+                    </div>
+                    <p><span className="text-zinc-500">Subject:</span> <span className="text-white">{subject}</span></p>
+                    <div className="rounded-lg border border-zinc-800 bg-zinc-950 px-3 py-2 max-h-40 overflow-y-auto whitespace-pre-wrap text-zinc-300">{message}</div>
+                  </div>
+                  <div className="flex justify-end gap-3">
+                    <button
+                      onClick={() => setShowConfirm(false)}
+                      disabled={sendState === 'sending'}
+                      className="px-4 py-2 text-sm rounded-lg border border-zinc-700 text-zinc-300 hover:bg-zinc-800 disabled:opacity-50 transition-colors"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={handleSend}
+                      disabled={sendState === 'sending'}
+                      className="px-4 py-2 text-sm rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white font-medium disabled:opacity-60 shadow-lg shadow-green-600/20 transition-all"
+                    >
+                      {sendState === 'sending' ? 'Sending...' : 'Confirm & Send'}
+                    </button>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </div>
         </div>
       )}

--- a/src/app/admin/(protected)/layout.tsx
+++ b/src/app/admin/(protected)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from 'next/navigation';
 import { isAdminAuthenticated } from '@/lib/adminSession';
 import AdminNav from './AdminNav';
+import AdminPageTransition from './AdminPageTransition';
 
 export default async function AdminProtectedLayout({ children }: { children: React.ReactNode }) {
   const authed = await isAdminAuthenticated();
@@ -12,7 +13,7 @@ export default async function AdminProtectedLayout({ children }: { children: Rea
     <div className="min-h-screen bg-black text-white flex">
       <AdminNav />
       <main className="flex-1 min-w-0 overflow-x-hidden">
-        {children}
+        <AdminPageTransition>{children}</AdminPageTransition>
       </main>
     </div>
   );

--- a/src/app/admin/(protected)/page.tsx
+++ b/src/app/admin/(protected)/page.tsx
@@ -1,25 +1,31 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Building2, FileQuestion, Send, ClipboardCheck, ArrowRight } from 'lucide-react';
+import { Building2, FileQuestion, Send, ClipboardCheck, ArrowRight, RefreshCw } from 'lucide-react';
+import { useAdminData } from './useAdminData';
+import { AdminPageLoading, AdminErrorState } from './AdminPageLoading';
+
+interface OverviewPayload {
+  totals: any;
+  recentCompanies: any[];
+}
 
 export default function AdminOverviewPage() {
-  const [totals, setTotals] = useState<any>(null);
-  const [recentCompanies, setRecentCompanies] = useState<any[]>([]);
+  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<OverviewPayload>('admin-overview', async () => {
+    const [analyticsRes, companiesRes] = await Promise.all([
+      fetch('/api/admin/analytics'),
+      fetch('/api/admin/companies'),
+    ]);
+    if (!analyticsRes.ok || !companiesRes.ok) {
+      throw new Error('Failed to load overview data');
+    }
+    const analytics = await analyticsRes.json();
+    const companies = await companiesRes.json();
+    return { totals: analytics.totals, recentCompanies: (companies.companies || []).slice(0, 8) };
+  });
 
-  useEffect(() => {
-    (async () => {
-      const [analyticsRes, companiesRes] = await Promise.all([
-        fetch('/api/admin/analytics'),
-        fetch('/api/admin/companies'),
-      ]);
-      const analytics = await analyticsRes.json();
-      const companies = await companiesRes.json();
-      setTotals(analytics.totals);
-      setRecentCompanies((companies.companies || []).slice(0, 8));
-    })();
-  }, []);
+  const totals = data?.totals;
+  const recentCompanies = data?.recentCompanies || [];
 
   const cards = [
     { label: 'Companies', value: totals?.total_companies, icon: Building2, href: '/admin/companies' },
@@ -28,9 +34,30 @@ export default function AdminOverviewPage() {
     { label: 'Quiz attempts', value: totals?.total_attempts, icon: ClipboardCheck, href: '/admin/results' },
   ];
 
+  if (isLoading) {
+    return <AdminPageLoading text="Loading overview..." />;
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 max-w-2xl mx-auto">
+        <AdminErrorState message={error} onRetry={refresh} />
+      </div>
+    );
+  }
+
   return (
     <div className="p-8 max-w-6xl mx-auto">
-      <h1 className="text-2xl font-semibold text-white mb-1">Overview</h1>
+      <div className="flex items-start justify-between mb-1">
+        <h1 className="text-2xl font-semibold text-white">Overview</h1>
+        <button
+          onClick={refresh}
+          disabled={isRefreshing}
+          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
+        </button>
+      </div>
       <p className="text-sm text-zinc-500 mb-8">Welcome to the QuizzViz internal admin panel.</p>
 
       <div className="grid grid-cols-4 gap-4 mb-8">

--- a/src/app/admin/(protected)/quizzes/QuizForm.tsx
+++ b/src/app/admin/(protected)/quizzes/QuizForm.tsx
@@ -85,8 +85,6 @@ export function QuizForm({
   const [role, setRole] = useState(initialData?.role || '');
   const [experience, setExperience] = useState(initialData?.experience || '');
   const [quizType, setQuizType] = useState(initialData?.quiz_type || 'technical');
-  const [theoryPct, setTheoryPct] = useState(initialData?.theory_questions_percentage ?? 70);
-  const [codePct, setCodePct] = useState(initialData?.code_analysis_questions_percentage ?? 30);
   const [questions, setQuestions] = useState<QuestionDraft[]>(toDrafts(initialData?.quiz));
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -128,7 +126,22 @@ export function QuizForm({
   const addQuestion = () => setQuestions((prev) => [...prev, emptyQuestion()]);
   const removeQuestion = (key: string) => setQuestions((prev) => (prev.length > 1 ? prev.filter((q) => q.key !== key) : prev));
 
-  const isNonTechnical = quizType === 'non_technical';
+  // Percentages are derived live from the actual question types instead of
+  // being separately typed-in numbers — that's what previously let a quiz's
+  // stored "Theory %" drift out of sync with what the questions actually were.
+  const composition = useMemo(() => {
+    const total = questions.length || 1;
+    const counts = { theory: 0, code_analysis: 0, practical_scenario: 0 } as Record<QuestionType, number>;
+    questions.forEach((q) => { counts[q.type] += 1; });
+    const theoryPct = Math.round((counts.theory / total) * 100);
+    return {
+      theoryPct,
+      nonTheoryPct: 100 - theoryPct,
+      breakdown: (Object.entries(counts) as [QuestionType, number][])
+        .filter(([, count]) => count > 0)
+        .map(([type, count]) => ({ type, pct: Math.round((count / total) * 100) })),
+    };
+  }, [questions]);
 
   const validate = (): string | null => {
     if (!companyId.trim()) return 'Pick a company.';
@@ -159,8 +172,8 @@ export function QuizForm({
         role: role.trim(),
         experience: experience.trim(),
         quiz_type: quizType,
-        theory_questions_percentage: Number(theoryPct) || 0,
-        code_analysis_questions_percentage: isNonTechnical ? 0 : Number(codePct) || 0,
+        theory_questions_percentage: composition.theoryPct,
+        code_analysis_questions_percentage: composition.nonTheoryPct,
         questions: questions.map((q) => ({
           type: q.type,
           question: q.question.trim(),
@@ -273,30 +286,16 @@ export function QuizForm({
               <option value="non_technical">Non-Technical</option>
             </select>
           </div>
-          <div>
-            <label className="text-xs text-zinc-500 mb-1 block">Theory %</label>
-            <input
-              type="number"
-              min={0}
-              max={100}
-              value={theoryPct}
-              onChange={(e) => setTheoryPct(Number(e.target.value))}
-              className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-green-500/40"
-            />
-          </div>
-          {!isNonTechnical && (
-            <div>
-              <label className="text-xs text-zinc-500 mb-1 block">Code analysis %</label>
-              <input
-                type="number"
-                min={0}
-                max={100}
-                value={codePct}
-                onChange={(e) => setCodePct(Number(e.target.value))}
-                className="w-full rounded-lg bg-zinc-900 border border-zinc-700 px-3 py-2 text-white text-sm focus:outline-none focus:ring-2 focus:ring-green-500/40"
-              />
+          <div className="col-span-2">
+            <label className="text-xs text-zinc-500 mb-1 block">Composition (auto-computed from questions below)</label>
+            <div className="flex items-center gap-2 flex-wrap">
+              {composition.breakdown.map(({ type, pct }) => (
+                <span key={type} className={`text-xs rounded-full px-2.5 py-1 border ${typeBadgeClass[type]}`}>
+                  {type === 'theory' ? 'Theory' : type === 'code_analysis' ? 'Code Analysis' : 'Practical Scenario'} {pct}%
+                </span>
+              ))}
             </div>
-          )}
+          </div>
         </div>
       </div>
 

--- a/src/app/admin/(protected)/quizzes/[quizId]/page.tsx
+++ b/src/app/admin/(protected)/quizzes/[quizId]/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Users, Trophy, TrendingUp, ExternalLink, Pencil } from 'lucide-react';
 import { QuizForm } from '../QuizForm';
+import { useAdminData, invalidateAdminData } from '../../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../../AdminPageLoading';
 
 interface Option {
   A: string; B: string; C: string; D: string;
@@ -58,45 +60,64 @@ function StatCard({ label, value, icon: Icon }: { label: string; value: string; 
   );
 }
 
+interface QuizDetailPayload {
+  quiz: QuizDetail;
+  stats: Stats;
+}
+
+// The DB only tracks two percentage columns (theory/code_analysis) but
+// questions actually come in three types (theory/code_analysis/practical_scenario).
+// Trusting the stored columns can lie about what's actually in the quiz (e.g. a
+// since-fixed generation bug could leave a stale split on older quizzes), so the
+// badges are computed live from the real question type counts instead.
+function computeTypeBreakdown(questions: QuizQuestion[]) {
+  if (questions.length === 0) return [];
+  const counts: Record<string, number> = {};
+  for (const q of questions) {
+    const type = q.type === 'code_analysis' || q.type === 'practical_scenario' ? q.type : 'theory';
+    counts[type] = (counts[type] || 0) + 1;
+  }
+  const labels: Record<string, { label: string; className: string }> = {
+    theory: { label: 'Theory', className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300' },
+    code_analysis: { label: 'Code Analysis', className: 'border-indigo-500/30 bg-indigo-500/10 text-indigo-300' },
+    practical_scenario: { label: 'Practical Scenario', className: 'border-purple-500/30 bg-purple-500/10 text-purple-300' },
+  };
+  return Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .map(([type, count]) => ({
+      ...labels[type],
+      pct: Math.round((count / questions.length) * 100),
+    }));
+}
+
 export default function AdminQuizDetailPage() {
   const params = useParams();
   const quizId = params?.quizId as string;
-  const [quiz, setQuiz] = useState<QuizDetail | null>(null);
-  const [stats, setStats] = useState<Stats | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const cacheKey = `admin-quiz-${quizId || 'unknown'}`;
   const [isEditing, setIsEditing] = useState(false);
 
-  const load = async () => {
-    if (!quizId) return;
-    setIsLoading(true);
-    try {
-      const res = await fetch(`/api/admin/quizzes/${encodeURIComponent(quizId)}`);
-      const data = await res.json();
-      if (!res.ok) {
-        setError(data.error || 'Failed to load quiz');
-        return;
-      }
-      setQuiz(data.quiz);
-      setStats(data.stats);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const { data, isLoading, error, refresh } = useAdminData<QuizDetailPayload>(cacheKey, async () => {
+    if (!quizId) throw new Error('Missing quiz id');
+    const res = await fetch(`/api/admin/quizzes/${encodeURIComponent(quizId)}`);
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || 'Failed to load quiz');
+    return { quiz: json.quiz, stats: json.stats };
+  });
 
-  useEffect(() => { load(); }, [quizId]);
+  const quiz = data?.quiz;
+  const stats = data?.stats;
+  const questions = useMemo(() => (quiz && Array.isArray(quiz.quiz) ? quiz.quiz : []), [quiz]);
+  const typeBreakdown = useMemo(() => computeTypeBreakdown(questions), [questions]);
 
-  if (isLoading) return <div className="p-8 text-zinc-500">Loading...</div>;
+  if (isLoading) return <AdminPageLoading text="Loading quiz..." />;
   if (error || !quiz) {
     return (
-      <div className="p-8">
-        <p className="text-red-400">{error || 'Quiz not found.'}</p>
-        <Link href="/admin/quizzes" className="text-green-400 text-sm mt-2 inline-block">Back to quizzes</Link>
+      <div className="p-8 max-w-2xl mx-auto">
+        {error ? <AdminErrorState message={error} onRetry={refresh} /> : <p className="text-red-400">Quiz not found.</p>}
+        <Link href="/admin/quizzes" className="text-green-400 text-sm mt-3 inline-block">Back to quizzes</Link>
       </div>
     );
   }
-
-  const questions = Array.isArray(quiz.quiz) ? quiz.quiz : [];
 
   if (isEditing) {
     return (
@@ -122,7 +143,8 @@ export default function AdminQuizDetailPage() {
           onCancel={() => setIsEditing(false)}
           onSaved={async () => {
             setIsEditing(false);
-            await load();
+            invalidateAdminData('admin-quizzes');
+            await refresh();
           }}
         />
       </div>
@@ -188,16 +210,13 @@ export default function AdminQuizDetailPage() {
         </div>
       )}
 
-      <div className="flex items-center gap-2 mb-4">
-        <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-3 py-1 text-emerald-300 text-xs">
-          Theory {quiz.theory_questions_percentage}%
-        </span>
-        {quiz.quiz_type !== 'non_technical' && (
-          <span className="rounded-full border border-indigo-500/30 bg-indigo-500/10 px-3 py-1 text-indigo-300 text-xs">
-            Code {quiz.code_analysis_questions_percentage}%
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        {typeBreakdown.map((t) => (
+          <span key={t.label} className={`rounded-full border px-3 py-1 text-xs ${t.className}`}>
+            {t.label} {t.pct}%
           </span>
-        )}
-        <span className="text-xs text-zinc-500">{questions.length} questions</span>
+        ))}
+        <span className="text-xs text-zinc-500">{questions.length} questions · computed from actual question types</span>
       </div>
 
       <div className="space-y-4">

--- a/src/app/admin/(protected)/quizzes/new/page.tsx
+++ b/src/app/admin/(protected)/quizzes/new/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { QuizForm } from '../QuizForm';
+import { invalidateAdminData } from '../../useAdminData';
 
 export default function NewQuizPage() {
   const router = useRouter();
@@ -18,7 +19,11 @@ export default function NewQuizPage() {
 
       <QuizForm
         mode="create"
-        onSaved={(quizId) => router.push(`/admin/quizzes/${encodeURIComponent(quizId)}`)}
+        onSaved={(quizId) => {
+          invalidateAdminData('admin-quizzes');
+          invalidateAdminData('admin-overview');
+          router.push(`/admin/quizzes/${encodeURIComponent(quizId)}`);
+        }}
       />
     </div>
   );

--- a/src/app/admin/(protected)/quizzes/page.tsx
+++ b/src/app/admin/(protected)/quizzes/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Trash2, Users, ChevronRight, Plus } from 'lucide-react';
+import { Trash2, Users, Plus, Search, RefreshCw } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
+import { useAdminData, invalidateAdminData } from '../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
 
 type StatusFilter = 'all' | 'draft' | 'published';
 
@@ -12,6 +14,7 @@ interface QuizRow {
   quiz_id: string;
   company_id: string;
   company_name: string | null;
+  company_owner_email: string | null;
   role: string;
   experience: string;
   num_questions: number;
@@ -24,24 +27,21 @@ interface QuizRow {
 
 export default function AdminQuizzesPage() {
   const { toast } = useToast();
-  const [quizzes, setQuizzes] = useState<QuizRow[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<QuizRow[]>('admin-quizzes', async () => {
+    const res = await fetch('/api/admin/quizzes');
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `Failed to load quizzes (${res.status})`);
+    }
+    const json = await res.json();
+    return json.quizzes || [];
+  });
+  const quizzes = data || [];
+
   const [deleteTarget, setDeleteTarget] = useState<QuizRow | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
-
-  const load = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch('/api/admin/quizzes');
-      const data = await res.json();
-      setQuizzes(data.quizzes || []);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => { load(); }, []);
+  const [search, setSearch] = useState('');
 
   const counts = useMemo(() => ({
     all: quizzes.length,
@@ -50,10 +50,21 @@ export default function AdminQuizzesPage() {
   }), [quizzes]);
 
   const visibleQuizzes = useMemo(() => {
-    if (statusFilter === 'draft') return quizzes.filter((q) => !q.quiz_public_link);
-    if (statusFilter === 'published') return quizzes.filter((q) => !!q.quiz_public_link);
-    return quizzes;
-  }, [quizzes, statusFilter]);
+    let rows = quizzes;
+    if (statusFilter === 'draft') rows = rows.filter((q) => !q.quiz_public_link);
+    else if (statusFilter === 'published') rows = rows.filter((q) => !!q.quiz_public_link);
+
+    const q = search.trim().toLowerCase();
+    if (q) {
+      rows = rows.filter((row) =>
+        row.role.toLowerCase().includes(q) ||
+        (row.company_name || '').toLowerCase().includes(q) ||
+        row.company_id.toLowerCase().includes(q) ||
+        (row.company_owner_email || '').toLowerCase().includes(q)
+      );
+    }
+    return rows;
+  }, [quizzes, statusFilter, search]);
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -67,7 +78,8 @@ export default function AdminQuizzesPage() {
           className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
         });
         setDeleteTarget(null);
-        load();
+        invalidateAdminData(`admin-quiz-${deleteTarget.quiz_id}`);
+        refresh();
       } else {
         const data = await res.json().catch(() => ({}));
         toast({ title: 'Delete failed', description: data.error || 'Failed to delete quiz', variant: 'destructive' });
@@ -87,29 +99,51 @@ export default function AdminQuizzesPage() {
     <div className="p-8 max-w-7xl mx-auto">
       <div className="flex items-start justify-between mb-1">
         <h1 className="text-2xl font-semibold text-white">Quizzes</h1>
-        <Link
-          href="/admin/quizzes/new"
-          className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white text-sm font-medium px-4 py-2"
-        >
-          <Plus className="h-4 w-4" /> New Quiz
-        </Link>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={refresh}
+            disabled={isRefreshing}
+            className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-2 transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
+          </button>
+          <Link
+            href="/admin/quizzes/new"
+            className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white text-sm font-medium px-4 py-2"
+          >
+            <Plus className="h-4 w-4" /> New Quiz
+          </Link>
+        </div>
       </div>
       <p className="text-sm text-zinc-500 mb-5">{visibleQuizzes.length} of {quizzes.length} quizzes shown (most recent 300) — click a row to view its questions</p>
 
-      <div className="flex items-center gap-1.5 mb-5 border border-zinc-800 rounded-lg p-1 w-fit bg-zinc-950">
-        {tabs.map((tab) => (
-          <button
-            key={tab.key}
-            onClick={() => setStatusFilter(tab.key)}
-            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-              statusFilter === tab.key
-                ? 'bg-gradient-to-r from-green-600/20 to-blue-600/20 text-white border border-green-500/30'
-                : 'text-zinc-400 hover:text-white hover:bg-zinc-900 border border-transparent'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+      {error && <div className="mb-5"><AdminErrorState message={error} onRetry={refresh} /></div>}
+
+      <div className="flex items-center gap-3 mb-5 flex-wrap">
+        <div className="flex items-center gap-1.5 border border-zinc-800 rounded-lg p-1 w-fit bg-zinc-950">
+          {tabs.map((tab) => (
+            <button
+              key={tab.key}
+              onClick={() => setStatusFilter(tab.key)}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+                statusFilter === tab.key
+                  ? 'bg-gradient-to-r from-green-600/20 to-blue-600/20 text-white border border-green-500/30'
+                  : 'text-zinc-400 hover:text-white hover:bg-zinc-900 border border-transparent'
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className="relative flex-1 min-w-[220px] max-w-sm">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-zinc-500" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by role, company, or owner email..."
+            className="w-full rounded-lg bg-zinc-900 border border-zinc-800 pl-9 pr-3 py-2 text-sm text-white placeholder:text-zinc-600 focus:outline-none focus:ring-2 focus:ring-green-500/40"
+          />
+        </div>
       </div>
 
       <div className="border border-zinc-800 rounded-xl overflow-hidden">
@@ -129,7 +163,7 @@ export default function AdminQuizzesPage() {
           </thead>
           <tbody className="divide-y divide-zinc-900">
             {isLoading ? (
-              <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
+              <tr><td colSpan={9} className="p-0"><AdminPageLoading /></td></tr>
             ) : visibleQuizzes.length === 0 ? (
               <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">No quizzes found</td></tr>
             ) : visibleQuizzes.map((q) => (
@@ -138,7 +172,10 @@ export default function AdminQuizzesPage() {
                   <Link href={`/admin/quizzes/${encodeURIComponent(q.quiz_id)}`} className="absolute inset-0 z-10" aria-label={`View ${q.role} quiz`} />
                   <span className="relative">{q.role}</span>
                 </td>
-                <td className="px-4 py-3 text-zinc-400">{q.company_name || q.company_id}</td>
+                <td className="px-4 py-3 text-zinc-400">
+                  <div>{q.company_name || q.company_id}</div>
+                  {q.company_owner_email && <div className="text-xs text-zinc-600">{q.company_owner_email}</div>}
+                </td>
                 <td className="px-4 py-3">
                   <span className={`text-xs rounded-full px-2 py-0.5 border ${q.quiz_type === 'non_technical' ? 'bg-purple-500/15 text-purple-300 border-purple-500/30' : 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30'}`}>
                     {q.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}

--- a/src/app/admin/(protected)/results/[id]/page.tsx
+++ b/src/app/admin/(protected)/results/[id]/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Trophy, CheckCircle2, XCircle } from 'lucide-react';
+import { useAdminData } from '../../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../../AdminPageLoading';
 
 interface Option { A: string; B: string; C: string; D: string; }
 
@@ -45,41 +46,34 @@ interface QuizInfo {
   quiz: QuizQuestion[];
 }
 
+interface AttemptPayload {
+  attempt: Attempt;
+  quiz: QuizInfo | null;
+  highest_score: number | null;
+}
+
 export default function AdminAttemptDetailPage() {
   const params = useParams();
   const id = params?.id as string;
-  const [attempt, setAttempt] = useState<Attempt | null>(null);
-  const [quiz, setQuiz] = useState<QuizInfo | null>(null);
-  const [highestScore, setHighestScore] = useState<number | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!id) return;
-    (async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch(`/api/admin/results/${encodeURIComponent(id)}`);
-        const data = await res.json();
-        if (!res.ok) {
-          setError(data.error || 'Failed to load attempt');
-          return;
-        }
-        setAttempt(data.attempt);
-        setQuiz(data.quiz);
-        setHighestScore(data.highest_score);
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, [id]);
+  const { data, isLoading, error, refresh } = useAdminData<AttemptPayload>(`admin-result-${id || 'unknown'}`, async () => {
+    if (!id) throw new Error('Missing attempt id');
+    const res = await fetch(`/api/admin/results/${encodeURIComponent(id)}`);
+    const json = await res.json();
+    if (!res.ok) throw new Error(json.error || 'Failed to load attempt');
+    return { attempt: json.attempt, quiz: json.quiz, highest_score: json.highest_score };
+  });
 
-  if (isLoading) return <div className="p-8 text-zinc-500">Loading...</div>;
+  const attempt = data?.attempt;
+  const quiz = data?.quiz;
+  const highestScore = data?.highest_score ?? null;
+
+  if (isLoading) return <AdminPageLoading text="Loading attempt..." />;
   if (error || !attempt) {
     return (
-      <div className="p-8">
-        <p className="text-red-400">{error || 'Attempt not found.'}</p>
-        <Link href="/admin/results" className="text-green-400 text-sm mt-2 inline-block">Back to attempts</Link>
+      <div className="p-8 max-w-2xl mx-auto">
+        {error ? <AdminErrorState message={error} onRetry={refresh} /> : <p className="text-red-400">Attempt not found.</p>}
+        <Link href="/admin/results" className="text-green-400 text-sm mt-3 inline-block">Back to attempts</Link>
       </div>
     );
   }

--- a/src/app/admin/(protected)/results/page.tsx
+++ b/src/app/admin/(protected)/results/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
-import { Trash2 } from 'lucide-react';
+import { Trash2, RefreshCw } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
+import { useAdminData } from '../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
 
 interface ResultRow {
   id: number;
@@ -20,23 +22,18 @@ interface ResultRow {
 
 export default function AdminResultsPage() {
   const { toast } = useToast();
-  const [results, setResults] = useState<ResultRow[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<ResultRow[]>('admin-results', async () => {
+    const res = await fetch('/api/admin/results');
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `Failed to load attempts (${res.status})`);
+    }
+    const json = await res.json();
+    return json.results || [];
+  });
+  const results = data || [];
   const [deleteTarget, setDeleteTarget] = useState<ResultRow | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
-
-  const load = async () => {
-    setIsLoading(true);
-    try {
-      const res = await fetch('/api/admin/results');
-      const data = await res.json();
-      setResults(data.results || []);
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  useEffect(() => { load(); }, []);
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -50,7 +47,7 @@ export default function AdminResultsPage() {
           className: 'border-green-600/60 bg-green-700 text-green-100 shadow-lg shadow-green-600/30',
         });
         setDeleteTarget(null);
-        load();
+        refresh();
       } else {
         const data = await res.json().catch(() => ({}));
         toast({ title: 'Delete failed', description: data.error || 'Failed to delete attempt', variant: 'destructive' });
@@ -62,8 +59,19 @@ export default function AdminResultsPage() {
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
-      <h1 className="text-2xl font-semibold text-white mb-1">Attempts / Results</h1>
+      <div className="flex items-start justify-between mb-1">
+        <h1 className="text-2xl font-semibold text-white">Attempts / Results</h1>
+        <button
+          onClick={refresh}
+          disabled={isRefreshing}
+          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
+        </button>
+      </div>
       <p className="text-sm text-zinc-500 mb-6">{results.length} attempts shown (most recent 300) — click a row for the full breakdown</p>
+
+      {error && <div className="mb-5"><AdminErrorState message={error} onRetry={refresh} /></div>}
 
       <div className="border border-zinc-800 rounded-xl overflow-hidden">
         <table className="w-full text-sm">
@@ -79,7 +87,7 @@ export default function AdminResultsPage() {
           </thead>
           <tbody className="divide-y divide-zinc-900">
             {isLoading ? (
-              <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
+              <tr><td colSpan={6} className="p-0"><AdminPageLoading /></td></tr>
             ) : results.length === 0 ? (
               <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">No attempts found</td></tr>
             ) : results.map((r) => (

--- a/src/app/admin/(protected)/usage/page.tsx
+++ b/src/app/admin/(protected)/usage/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { Gauge } from 'lucide-react';
+import { Gauge, RefreshCw } from 'lucide-react';
+import { useAdminData } from '../useAdminData';
+import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
 
 interface UsageRow {
   company_id: string;
@@ -45,32 +46,38 @@ function UsageBar({ used, limit, pct }: { used: number; limit: number; pct: numb
 }
 
 export default function AdminUsagePage() {
-  const [usage, setUsage] = useState<UsageRow[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-
-  useEffect(() => {
-    (async () => {
-      setIsLoading(true);
-      try {
-        const res = await fetch('/api/admin/usage');
-        const data = await res.json();
-        setUsage(data.usage || []);
-      } finally {
-        setIsLoading(false);
-      }
-    })();
-  }, []);
+  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<UsageRow[]>('admin-usage', async () => {
+    const res = await fetch('/api/admin/usage');
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body.error || `Failed to load usage (${res.status})`);
+    }
+    const json = await res.json();
+    return json.usage || [];
+  });
+  const usage = data || [];
 
   return (
     <div className="p-8 max-w-6xl mx-auto">
-      <div className="flex items-center gap-2.5 mb-1">
-        <Gauge className="h-5 w-5 text-green-400" />
-        <h1 className="text-2xl font-semibold text-white">Usage</h1>
+      <div className="flex items-center justify-between mb-1">
+        <div className="flex items-center gap-2.5">
+          <Gauge className="h-5 w-5 text-green-400" />
+          <h1 className="text-2xl font-semibold text-white">Usage</h1>
+        </div>
+        <button
+          onClick={refresh}
+          disabled={isRefreshing}
+          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
+        </button>
       </div>
       <p className="text-sm text-zinc-500 mb-6">
         How much of each company&apos;s current billing period quota has been used — anchored to their actual subscription
         cycle, not the calendar month.
       </p>
+
+      {error && <div className="mb-5"><AdminErrorState message={error} onRetry={refresh} /></div>}
 
       <div className="border border-zinc-800 rounded-xl overflow-hidden">
         <table className="w-full text-sm">
@@ -85,8 +92,8 @@ export default function AdminUsagePage() {
           </thead>
           <tbody className="divide-y divide-zinc-900">
             {isLoading ? (
-              <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">Loading...</td></tr>
-            ) : usage.length === 0 ? (
+              <tr><td colSpan={5} className="p-0"><AdminPageLoading /></td></tr>
+            ) : error ? null : usage.length === 0 ? (
               <tr><td colSpan={5} className="px-4 py-8 text-center text-zinc-500">No companies found</td></tr>
             ) : usage.map((u) => (
               <tr key={u.company_id} className="hover:bg-zinc-900/60">

--- a/src/app/admin/(protected)/useAdminData.ts
+++ b/src/app/admin/(protected)/useAdminData.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Module-level cache: survives component unmount/remount across client-side
+// navigation (there's no SWR/react-query in this app), and is only cleared
+// by a full page reload. This is what makes revisiting a tab instant instead
+// of re-showing a loading spinner for data that hasn't changed.
+const cache = new Map<string, unknown>();
+
+export function invalidateAdminData(key: string) {
+  cache.delete(key);
+}
+
+export function useAdminData<T>(key: string, fetcher: () => Promise<T>) {
+  const hasCached = cache.has(key);
+  const [data, setData] = useState<T | undefined>(() => cache.get(key) as T | undefined);
+  const [isLoading, setIsLoading] = useState(!hasCached);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const run = useCallback(async (opts?: { silent?: boolean }) => {
+    if (opts?.silent) setIsRefreshing(true);
+    else setIsLoading(true);
+    setError(null);
+    try {
+      const result = await fetcherRef.current();
+      cache.set(key, result);
+      setData(result);
+    } catch (e: any) {
+      setError(e?.message || 'Something went wrong. Please try again.');
+    } finally {
+      setIsLoading(false);
+      setIsRefreshing(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  useEffect(() => {
+    if (!cache.has(key)) {
+      run();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+
+  const refresh = useCallback(() => run({ silent: cache.has(key) }), [run, key]);
+
+  return { data, isLoading, isRefreshing, error, refresh, setData };
+}

--- a/src/app/api/admin/quizzes/route.ts
+++ b/src/app/api/admin/quizzes/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: NextRequest) {
     const result = await db.query(
       `SELECT g.quiz_id, g.company_id, g.role, g.experience, g.num_questions, g.quiz_type,
               g.is_publish, g.is_deleted, g.created_at, c.name AS company_name,
+              c.owner_email AS company_owner_email,
               p.quiz_public_link,
               COALESCE(a.attempt_count, 0) AS attempt_count
        FROM generated_quizzes g

--- a/src/app/api/admin/send-email/route.ts
+++ b/src/app/api/admin/send-email/route.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminSession } from '@/lib/adminSession';
 
 const SUPPORT_SENDER_EMAIL = 'support@quizzviz.com';
+// The mail microservice validates email_type against a fixed enum. 'contact',
+// 'feedback', and 'report_bug' are the only values proven to work elsewhere
+// in this app (src/app/api/send_email/route.ts, dashboard feedback/report-bug
+// forms) — 'admin_notice' isn't in that enum and gets rejected with a 422.
+const EMAIL_TYPE = 'contact';
 
 export async function POST(request: NextRequest) {
   if (!requireAdminSession(request)) {
@@ -29,14 +34,15 @@ export async function POST(request: NextRequest) {
         recipient_email: recipient_email.trim(),
         subject: subject.trim().substring(0, 200),
         message: message.trim().substring(0, 10000),
-        email_type: 'admin_notice',
+        email_type: EMAIL_TYPE,
       }),
     });
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
+      const upstreamMessage = errorData.message || errorData.error || JSON.stringify(errorData);
       return NextResponse.json(
-        { error: errorData.message || `Failed to send email. Status: ${response.status}` },
+        { error: `Mail service rejected the request (${response.status}): ${upstreamMessage}` },
         { status: 502 }
       );
     }

--- a/src/lib/adminDb.ts
+++ b/src/lib/adminDb.ts
@@ -23,6 +23,10 @@ export function getAdminDb(): Pool {
       connectionString,
       ssl: { rejectUnauthorized: false },
       max: 5,
+      // Without this, an unresponsive/cold connection just hangs indefinitely
+      // (pg's default is to wait forever) instead of failing fast — the admin
+      // UI would rather show a clear, retryable error in ~10s than spin silently.
+      connectionTimeoutMillis: 10000,
     });
   }
   return pool;


### PR DESCRIPTION
- Fix email 422 by changing email_type from 'admin_notice' (unused anywhere in the app) to 'contact', a value already proven to work against the mail microservice; also forward the real upstream error instead of a generic one
- Fix Theory/Code % badges lying about quiz content: compute them live from actual per-question types instead of trusting stored DB columns that can drift out of sync (root-caused to a since-fixed generation bug); QuizForm's manual percentage inputs are replaced with the same live computation
- Add a shared useAdminData cache hook (module-level cache + invalidate on mutation) and apply it to every admin list/detail page, fixing both the Analytics tab always re-showing a loading spinner on revisit and the Quizzes list silently rendering "No quizzes found" on a swallowed 401/500 instead of a real error
- Add connectionTimeoutMillis to the admin Postgres pool so a stalled connection fails fast with a visible error instead of hanging
- Hide the Users tab from the sidebar (page/API left in place, unlinked)
- Add multi-recipient chips to Email Customers for sending one email to many people at once, plus a spring-animated "Sent" confirmation matching the Dashboard feedback page's visual language, auto-resetting the form
- Add search (role/company/owner email) and a Refresh button to the Quizzes list
- Polish shared admin chrome: sliding active-tab nav indicator, smooth tab transitions, and a proper spinner in place of plain "Loading..." text