### PR TITLE
fix: dashboard reload bugs, admin refresh/pagination, and answer colo…

### DIFF
--- a/src/app/admin/(protected)/AdminPagination.tsx
+++ b/src/app/admin/(protected)/AdminPagination.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+export const ADMIN_PAGE_SIZE = 100;
+
+export function AdminPagination({
+  page,
+  pageCount,
+  onPageChange,
+}: {
+  page: number;
+  pageCount: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (pageCount <= 1) return null;
+
+  return (
+    <div className="flex items-center justify-between mt-4">
+      <button
+        onClick={() => onPageChange(Math.max(1, page - 1))}
+        disabled={page <= 1}
+        className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+      >
+        <ChevronLeft className="h-3.5 w-3.5" /> Prev
+      </button>
+      <span className="text-sm text-zinc-500">Page {page} of {pageCount}</span>
+      <button
+        onClick={() => onPageChange(Math.min(pageCount, page + 1))}
+        disabled={page >= pageCount}
+        className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-40 disabled:pointer-events-none"
+      >
+        Next <ChevronRight className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export default AdminPagination;

--- a/src/app/admin/(protected)/AdminRefreshButton.tsx
+++ b/src/app/admin/(protected)/AdminRefreshButton.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Loader2, RefreshCw } from 'lucide-react';
+
+// Matches the Dashboard's Refresh button (src/pages/dashboard/analytics/index.tsx)
+// exactly, so the admin panel and the customer-facing Dashboard feel like the
+// same product wherever a "Refresh" control appears.
+export function AdminRefreshButton({
+  onClick,
+  isRefreshing,
+  lastUpdated,
+}: {
+  onClick: () => void;
+  isRefreshing: boolean;
+  lastUpdated?: number | null;
+}) {
+  return (
+    <div className="flex items-center gap-4">
+      {lastUpdated && (
+        <div className="text-sm text-zinc-400">
+          Last updated: {new Date(lastUpdated).toLocaleString()}
+        </div>
+      )}
+      <button
+        onClick={onClick}
+        disabled={isRefreshing}
+        className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md h-10 px-4 py-2 text-sm font-medium bg-gradient-to-r from-green-500 to-blue-500 text-white hover:brightness-110 transition-all duration-300 shadow-md hover:shadow-xl disabled:opacity-50 disabled:pointer-events-none"
+      >
+        {isRefreshing ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span>Refreshing...</span>
+          </>
+        ) : (
+          <>
+            <RefreshCw className="h-4 w-4" />
+            <span>Refresh</span>
+          </>
+        )}
+      </button>
+    </div>
+  );
+}
+
+export default AdminRefreshButton;

--- a/src/app/admin/(protected)/analytics/page.tsx
+++ b/src/app/admin/(protected)/analytics/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { RefreshCw } from 'lucide-react';
 import {
   ResponsiveContainer, LineChart, Line, BarChart, Bar, XAxis, YAxis,
   CartesianGrid, Tooltip, Legend,
@@ -9,6 +8,7 @@ import {
 import { TrendingUp, TrendingDown, Building2, FileQuestion, Send, ClipboardCheck } from 'lucide-react';
 import { useAdminData } from '../useAdminData';
 import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
+import { AdminRefreshButton } from '../AdminRefreshButton';
 
 interface MonthlyPoint {
   year: number;
@@ -57,7 +57,7 @@ interface AnalyticsPayload {
 }
 
 export default function AdminAnalyticsPage() {
-  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<AnalyticsPayload>('admin-analytics', async () => {
+  const { data, isLoading, isRefreshing, error, refresh, lastUpdated } = useAdminData<AnalyticsPayload>('admin-analytics', async () => {
     const res = await fetch('/api/admin/analytics');
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
@@ -122,13 +122,7 @@ export default function AdminAnalyticsPage() {
     <div className="p-8 max-w-7xl mx-auto">
       <div className="flex items-start justify-between mb-1">
         <h1 className="text-2xl font-semibold text-white">Growth Analytics</h1>
-        <button
-          onClick={refresh}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
-        </button>
+        <AdminRefreshButton onClick={refresh} isRefreshing={isRefreshing} lastUpdated={lastUpdated} />
       </div>
       <p className="text-sm text-zinc-500 mb-6">QuizzViz platform growth — quiz generation, publishing, and attempts over time.</p>
 

--- a/src/app/admin/(protected)/companies/page.tsx
+++ b/src/app/admin/(protected)/companies/page.tsx
@@ -1,10 +1,12 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Search, ChevronRight, RefreshCw } from 'lucide-react';
+import { Search, ChevronRight } from 'lucide-react';
 import { useAdminData } from '../useAdminData';
 import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
+import { AdminRefreshButton } from '../AdminRefreshButton';
+import { AdminPagination, ADMIN_PAGE_SIZE } from '../AdminPagination';
 
 interface Company {
   company_id: string;
@@ -38,7 +40,7 @@ function expiryStatus(expiry: string | null): { label: string; className: string
 }
 
 export default function AdminCompaniesPage() {
-  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<Company[]>('admin-companies', async () => {
+  const { data, isLoading, isRefreshing, error, refresh, lastUpdated } = useAdminData<Company[]>('admin-companies', async () => {
     const res = await fetch('/api/admin/companies');
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
@@ -51,8 +53,10 @@ export default function AdminCompaniesPage() {
   const [search, setSearch] = useState('');
   const [searchResults, setSearchResults] = useState<Company[] | null>(null);
   const [isSearching, setIsSearching] = useState(false);
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
+    setPage(1);
     if (!search) { setSearchResults(null); return; }
     setIsSearching(true);
     const t = setTimeout(async () => {
@@ -68,6 +72,11 @@ export default function AdminCompaniesPage() {
   }, [search]);
 
   const companies = searchResults ?? data ?? [];
+  const pageCount = Math.max(1, Math.ceil(companies.length / ADMIN_PAGE_SIZE));
+  const pagedCompanies = useMemo(
+    () => companies.slice((page - 1) * ADMIN_PAGE_SIZE, page * ADMIN_PAGE_SIZE),
+    [companies, page]
+  );
 
   return (
     <div className="p-8 max-w-7xl mx-auto">
@@ -76,13 +85,7 @@ export default function AdminCompaniesPage() {
           <h1 className="text-2xl font-semibold text-white">Companies & Billing</h1>
           <p className="text-sm text-zinc-500 mt-1">{companies.length} companies shown</p>
         </div>
-        <button
-          onClick={refresh}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
-        </button>
+        <AdminRefreshButton onClick={refresh} isRefreshing={isRefreshing} lastUpdated={lastUpdated} />
       </div>
 
       {error && <div className="mb-5"><AdminErrorState message={error} onRetry={refresh} /></div>}
@@ -114,7 +117,7 @@ export default function AdminCompaniesPage() {
               <tr><td colSpan={6} className="p-0"><AdminPageLoading /></td></tr>
             ) : companies.length === 0 ? (
               <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">No companies found</td></tr>
-            ) : companies.map((c) => {
+            ) : pagedCompanies.map((c) => {
               const status = expiryStatus(c.plan_expiry_date);
               return (
                 <tr key={c.company_id} className="hover:bg-zinc-900/60">
@@ -144,6 +147,7 @@ export default function AdminCompaniesPage() {
           </tbody>
         </table>
       </div>
+      <AdminPagination page={page} pageCount={pageCount} onPageChange={setPage} />
     </div>
   );
 }

--- a/src/app/admin/(protected)/page.tsx
+++ b/src/app/admin/(protected)/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { Building2, FileQuestion, Send, ClipboardCheck, ArrowRight, RefreshCw } from 'lucide-react';
+import { Building2, FileQuestion, Send, ClipboardCheck, ArrowRight } from 'lucide-react';
 import { useAdminData } from './useAdminData';
 import { AdminPageLoading, AdminErrorState } from './AdminPageLoading';
+import { AdminRefreshButton } from './AdminRefreshButton';
 
 interface OverviewPayload {
   totals: any;
@@ -11,7 +12,7 @@ interface OverviewPayload {
 }
 
 export default function AdminOverviewPage() {
-  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<OverviewPayload>('admin-overview', async () => {
+  const { data, isLoading, isRefreshing, error, refresh, lastUpdated } = useAdminData<OverviewPayload>('admin-overview', async () => {
     const [analyticsRes, companiesRes] = await Promise.all([
       fetch('/api/admin/analytics'),
       fetch('/api/admin/companies'),
@@ -50,13 +51,7 @@ export default function AdminOverviewPage() {
     <div className="p-8 max-w-6xl mx-auto">
       <div className="flex items-start justify-between mb-1">
         <h1 className="text-2xl font-semibold text-white">Overview</h1>
-        <button
-          onClick={refresh}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
-        </button>
+        <AdminRefreshButton onClick={refresh} isRefreshing={isRefreshing} lastUpdated={lastUpdated} />
       </div>
       <p className="text-sm text-zinc-500 mb-8">Welcome to the QuizzViz internal admin panel.</p>
 

--- a/src/app/admin/(protected)/quizzes/page.tsx
+++ b/src/app/admin/(protected)/quizzes/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Trash2, Users, Plus, Search, RefreshCw } from 'lucide-react';
+import { Trash2, Users, Plus, Search } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
 import { useAdminData, invalidateAdminData } from '../useAdminData';
 import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
+import { AdminRefreshButton } from '../AdminRefreshButton';
+import { AdminPagination, ADMIN_PAGE_SIZE } from '../AdminPagination';
 
 type StatusFilter = 'all' | 'draft' | 'published';
 
@@ -27,7 +29,7 @@ interface QuizRow {
 
 export default function AdminQuizzesPage() {
   const { toast } = useToast();
-  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<QuizRow[]>('admin-quizzes', async () => {
+  const { data, isLoading, isRefreshing, error, refresh, lastUpdated } = useAdminData<QuizRow[]>('admin-quizzes', async () => {
     const res = await fetch('/api/admin/quizzes');
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
@@ -42,6 +44,9 @@ export default function AdminQuizzesPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
   const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+
+  useEffect(() => { setPage(1); }, [statusFilter, search]);
 
   const counts = useMemo(() => ({
     all: quizzes.length,
@@ -65,6 +70,12 @@ export default function AdminQuizzesPage() {
     }
     return rows;
   }, [quizzes, statusFilter, search]);
+
+  const pageCount = Math.max(1, Math.ceil(visibleQuizzes.length / ADMIN_PAGE_SIZE));
+  const pagedQuizzes = useMemo(
+    () => visibleQuizzes.slice((page - 1) * ADMIN_PAGE_SIZE, page * ADMIN_PAGE_SIZE),
+    [visibleQuizzes, page]
+  );
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -100,13 +111,7 @@ export default function AdminQuizzesPage() {
       <div className="flex items-start justify-between mb-1">
         <h1 className="text-2xl font-semibold text-white">Quizzes</h1>
         <div className="flex items-center gap-2">
-          <button
-            onClick={refresh}
-            disabled={isRefreshing}
-            className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-2 transition-colors disabled:opacity-50"
-          >
-            <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
-          </button>
+          <AdminRefreshButton onClick={refresh} isRefreshing={isRefreshing} lastUpdated={lastUpdated} />
           <Link
             href="/admin/quizzes/new"
             className="flex items-center gap-2 rounded-lg bg-gradient-to-r from-green-600 to-blue-600 hover:from-green-700 hover:to-blue-700 text-white text-sm font-medium px-4 py-2"
@@ -146,18 +151,18 @@ export default function AdminQuizzesPage() {
         </div>
       </div>
 
-      <div className="border border-zinc-800 rounded-xl overflow-hidden">
+      <div className="border border-zinc-800 rounded-xl overflow-x-auto">
         <table className="w-full text-sm">
           <thead className="bg-zinc-900 text-zinc-400">
             <tr>
-              <th className="text-left px-4 py-3 font-medium">Role</th>
-              <th className="text-left px-4 py-3 font-medium">Company</th>
-              <th className="text-left px-4 py-3 font-medium">Type</th>
-              <th className="text-left px-4 py-3 font-medium">Experience</th>
-              <th className="text-left px-4 py-3 font-medium">Questions</th>
-              <th className="text-left px-4 py-3 font-medium">Attempts</th>
-              <th className="text-left px-4 py-3 font-medium">Status</th>
-              <th className="text-left px-4 py-3 font-medium">Created</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Role</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Company</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Type</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Experience</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Questions</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Attempts</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Status</th>
+              <th className="text-left px-4 py-3 font-medium whitespace-nowrap">Created</th>
               <th className="px-4 py-3"></th>
             </tr>
           </thead>
@@ -166,37 +171,37 @@ export default function AdminQuizzesPage() {
               <tr><td colSpan={9} className="p-0"><AdminPageLoading /></td></tr>
             ) : visibleQuizzes.length === 0 ? (
               <tr><td colSpan={9} className="px-4 py-8 text-center text-zinc-500">No quizzes found</td></tr>
-            ) : visibleQuizzes.map((q) => (
+            ) : pagedQuizzes.map((q) => (
               <tr key={q.quiz_id} className="hover:bg-zinc-900/60 relative">
-                <td className="px-4 py-3 text-white">
+                <td className="px-4 py-3 text-white whitespace-nowrap max-w-[200px] truncate">
                   <Link href={`/admin/quizzes/${encodeURIComponent(q.quiz_id)}`} className="absolute inset-0 z-10" aria-label={`View ${q.role} quiz`} />
-                  <span className="relative">{q.role}</span>
+                  <span className="relative" title={q.role}>{q.role}</span>
                 </td>
-                <td className="px-4 py-3 text-zinc-400">
-                  <div>{q.company_name || q.company_id}</div>
-                  {q.company_owner_email && <div className="text-xs text-zinc-600">{q.company_owner_email}</div>}
+                <td className="px-4 py-3 text-zinc-400 whitespace-nowrap max-w-[220px]">
+                  <div className="truncate" title={q.company_name || q.company_id}>{q.company_name || q.company_id}</div>
+                  {q.company_owner_email && <div className="text-xs text-zinc-600 truncate" title={q.company_owner_email}>{q.company_owner_email}</div>}
                 </td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   <span className={`text-xs rounded-full px-2 py-0.5 border ${q.quiz_type === 'non_technical' ? 'bg-purple-500/15 text-purple-300 border-purple-500/30' : 'bg-cyan-500/15 text-cyan-300 border-cyan-500/30'}`}>
                     {q.quiz_type === 'non_technical' ? 'Non-Technical' : 'Technical'}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-zinc-400">{q.experience}</td>
-                <td className="px-4 py-3 text-zinc-400">{q.num_questions}</td>
-                <td className="px-4 py-3 text-zinc-400">
+                <td className="px-4 py-3 text-zinc-400 whitespace-nowrap">{q.experience}</td>
+                <td className="px-4 py-3 text-zinc-400 whitespace-nowrap">{q.num_questions}</td>
+                <td className="px-4 py-3 text-zinc-400 whitespace-nowrap">
                   <span className="inline-flex items-center gap-1">
                     <Users className="h-3.5 w-3.5" /> {q.attempt_count}
                   </span>
                 </td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 whitespace-nowrap">
                   {q.quiz_public_link ? (
                     <span className="text-xs rounded-full px-2 py-0.5 bg-green-500/15 text-green-300 border border-green-500/30">Published</span>
                   ) : (
                     <span className="text-xs rounded-full px-2 py-0.5 bg-zinc-500/15 text-zinc-400 border border-zinc-500/30">Draft</span>
                   )}
                 </td>
-                <td className="px-4 py-3 text-zinc-500">{new Date(q.created_at).toLocaleDateString()}</td>
-                <td className="px-4 py-3 text-right relative z-20">
+                <td className="px-4 py-3 text-zinc-500 whitespace-nowrap">{new Date(q.created_at).toLocaleDateString()}</td>
+                <td className="px-4 py-3 text-right relative z-20 whitespace-nowrap">
                   <button onClick={() => setDeleteTarget(q)} className="text-zinc-500 hover:text-red-400">
                     <Trash2 className="h-4 w-4" />
                   </button>
@@ -206,6 +211,7 @@ export default function AdminQuizzesPage() {
           </tbody>
         </table>
       </div>
+      <AdminPagination page={page} pageCount={pageCount} onPageChange={setPage} />
 
       <ConfirmDeleteModal
         isOpen={!!deleteTarget}

--- a/src/app/admin/(protected)/results/[id]/page.tsx
+++ b/src/app/admin/(protected)/results/[id]/page.tsx
@@ -20,7 +20,7 @@ interface QuizQuestion {
 
 interface UserAnswer {
   question_id: string;
-  answer: string;
+  user_answer: string;
   is_correct: boolean;
 }
 
@@ -128,7 +128,7 @@ export default function AdminAttemptDetailPage() {
       <div className="space-y-4">
         {questions.map((q, idx) => {
           const ans = answersByQuestionId.get(String(q.id));
-          const userAnswer = ans?.answer;
+          const userAnswer = ans?.user_answer;
           const isCorrect = ans?.is_correct ?? (userAnswer === q.correct_answer);
           return (
             <div key={q.id ?? idx} className="bg-zinc-950 border border-zinc-800 rounded-xl p-5">

--- a/src/app/admin/(protected)/results/page.tsx
+++ b/src/app/admin/(protected)/results/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Trash2, RefreshCw } from 'lucide-react';
+import { Trash2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { ConfirmDeleteModal } from '../ConfirmDeleteModal';
 import { useAdminData } from '../useAdminData';
 import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
+import { AdminRefreshButton } from '../AdminRefreshButton';
+import { AdminPagination, ADMIN_PAGE_SIZE } from '../AdminPagination';
 
 interface ResultRow {
   id: number;
@@ -22,7 +24,7 @@ interface ResultRow {
 
 export default function AdminResultsPage() {
   const { toast } = useToast();
-  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<ResultRow[]>('admin-results', async () => {
+  const { data, isLoading, isRefreshing, error, refresh, lastUpdated } = useAdminData<ResultRow[]>('admin-results', async () => {
     const res = await fetch('/api/admin/results');
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
@@ -34,6 +36,12 @@ export default function AdminResultsPage() {
   const results = data || [];
   const [deleteTarget, setDeleteTarget] = useState<ResultRow | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [page, setPage] = useState(1);
+  const pageCount = Math.max(1, Math.ceil(results.length / ADMIN_PAGE_SIZE));
+  const pagedResults = useMemo(
+    () => results.slice((page - 1) * ADMIN_PAGE_SIZE, page * ADMIN_PAGE_SIZE),
+    [results, page]
+  );
 
   const handleDelete = async () => {
     if (!deleteTarget) return;
@@ -61,13 +69,7 @@ export default function AdminResultsPage() {
     <div className="p-8 max-w-7xl mx-auto">
       <div className="flex items-start justify-between mb-1">
         <h1 className="text-2xl font-semibold text-white">Attempts / Results</h1>
-        <button
-          onClick={refresh}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
-        </button>
+        <AdminRefreshButton onClick={refresh} isRefreshing={isRefreshing} lastUpdated={lastUpdated} />
       </div>
       <p className="text-sm text-zinc-500 mb-6">{results.length} attempts shown (most recent 300) — click a row for the full breakdown</p>
 
@@ -90,7 +92,7 @@ export default function AdminResultsPage() {
               <tr><td colSpan={6} className="p-0"><AdminPageLoading /></td></tr>
             ) : results.length === 0 ? (
               <tr><td colSpan={6} className="px-4 py-8 text-center text-zinc-500">No attempts found</td></tr>
-            ) : results.map((r) => (
+            ) : pagedResults.map((r) => (
               <tr key={r.id} className="hover:bg-zinc-900/60 relative">
                 <td className="px-4 py-3">
                   <Link href={`/admin/results/${r.id}`} className="absolute inset-0 z-10" aria-label={`View ${r.username}'s attempt`} />
@@ -111,6 +113,7 @@ export default function AdminResultsPage() {
           </tbody>
         </table>
       </div>
+      <AdminPagination page={page} pageCount={pageCount} onPageChange={setPage} />
 
       <ConfirmDeleteModal
         isOpen={!!deleteTarget}

--- a/src/app/admin/(protected)/usage/page.tsx
+++ b/src/app/admin/(protected)/usage/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { Gauge, RefreshCw } from 'lucide-react';
+import { Gauge } from 'lucide-react';
 import { useAdminData } from '../useAdminData';
 import { AdminPageLoading, AdminErrorState } from '../AdminPageLoading';
+import { AdminRefreshButton } from '../AdminRefreshButton';
 
 interface UsageRow {
   company_id: string;
@@ -46,7 +47,7 @@ function UsageBar({ used, limit, pct }: { used: number; limit: number; pct: numb
 }
 
 export default function AdminUsagePage() {
-  const { data, isLoading, isRefreshing, error, refresh } = useAdminData<UsageRow[]>('admin-usage', async () => {
+  const { data, isLoading, isRefreshing, error, refresh, lastUpdated } = useAdminData<UsageRow[]>('admin-usage', async () => {
     const res = await fetch('/api/admin/usage');
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
@@ -64,13 +65,7 @@ export default function AdminUsagePage() {
           <Gauge className="h-5 w-5 text-green-400" />
           <h1 className="text-2xl font-semibold text-white">Usage</h1>
         </div>
-        <button
-          onClick={refresh}
-          disabled={isRefreshing}
-          className="flex items-center gap-1.5 text-sm text-zinc-400 hover:text-white border border-zinc-700 hover:border-zinc-600 rounded-lg px-3 py-1.5 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`h-3.5 w-3.5 ${isRefreshing ? 'animate-spin' : ''}`} /> Refresh
-        </button>
+        <AdminRefreshButton onClick={refresh} isRefreshing={isRefreshing} lastUpdated={lastUpdated} />
       </div>
       <p className="text-sm text-zinc-500 mb-6">
         How much of each company&apos;s current billing period quota has been used — anchored to their actual subscription

--- a/src/app/admin/(protected)/useAdminData.ts
+++ b/src/app/admin/(protected)/useAdminData.ts
@@ -7,19 +7,31 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 // by a full page reload. This is what makes revisiting a tab instant instead
 // of re-showing a loading spinner for data that hasn't changed.
 const cache = new Map<string, unknown>();
+const lastUpdatedCache = new Map<string, number>();
 
 export function invalidateAdminData(key: string) {
   cache.delete(key);
+  lastUpdatedCache.delete(key);
 }
 
 export function useAdminData<T>(key: string, fetcher: () => Promise<T>) {
   const hasCached = cache.has(key);
-  const [data, setData] = useState<T | undefined>(() => cache.get(key) as T | undefined);
+  const [data, setDataState] = useState<T | undefined>(() => cache.get(key) as T | undefined);
+  const [lastUpdated, setLastUpdated] = useState<number | null>(() => lastUpdatedCache.get(key) ?? null);
   const [isLoading, setIsLoading] = useState(!hasCached);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const fetcherRef = useRef(fetcher);
   fetcherRef.current = fetcher;
+
+  const setData = useCallback((value: T) => {
+    const now = Date.now();
+    cache.set(key, value);
+    lastUpdatedCache.set(key, now);
+    setDataState(value);
+    setLastUpdated(now);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
 
   const run = useCallback(async (opts?: { silent?: boolean }) => {
     if (opts?.silent) setIsRefreshing(true);
@@ -27,7 +39,6 @@ export function useAdminData<T>(key: string, fetcher: () => Promise<T>) {
     setError(null);
     try {
       const result = await fetcherRef.current();
-      cache.set(key, result);
       setData(result);
     } catch (e: any) {
       setError(e?.message || 'Something went wrong. Please try again.');
@@ -36,7 +47,7 @@ export function useAdminData<T>(key: string, fetcher: () => Promise<T>) {
       setIsRefreshing(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+  }, [key, setData]);
 
   useEffect(() => {
     if (!cache.has(key)) {
@@ -47,5 +58,5 @@ export function useAdminData<T>(key: string, fetcher: () => Promise<T>) {
 
   const refresh = useCallback(() => run({ silent: cache.has(key) }), [run, key]);
 
-  return { data, isLoading, isRefreshing, error, refresh, setData };
+  return { data, isLoading, isRefreshing, error, refresh, setData, lastUpdated };
 }

--- a/src/hooks/useCachedData.ts
+++ b/src/hooks/useCachedData.ts
@@ -43,6 +43,14 @@ const clearStoredCache = (cacheKey: string) => {
   }
 };
 
+// Module-level (not per-component-instance) so the cache survives a
+// component unmounting and remounting — e.g. navigating away from a page
+// and back — instead of being thrown away every time. A per-instance
+// useRef only helps with re-renders of the *same* mounted instance, which
+// is why pages depending on this (via useUserRole) used to show a full
+// loading spinner on every single revisit even when nothing had changed.
+const globalCache = new Map<string, CacheEntry<any>>();
+
 export function useCachedData<T>({
   fetcher,
   dependencies,
@@ -54,19 +62,16 @@ export function useCachedData<T>({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Use ref to persist cache across re-renders
-  const cacheRef = useRef<Map<string, CacheEntry<T>>>(new Map());
-
   useEffect(() => {
     const now = Date.now();
-    let cached = cacheRef.current.get(cacheKey);
+    let cached = globalCache.get(cacheKey) as CacheEntry<T> | undefined;
 
     // Check localStorage cache first if persistent caching is enabled
     if (usePersistentCache && !cached) {
       const storedCache = getStoredCache<T>(cacheKey);
       if (storedCache) {
         cached = storedCache;
-        cacheRef.current.set(cacheKey, storedCache);
+        globalCache.set(cacheKey, storedCache);
       }
     }
 
@@ -89,7 +94,7 @@ export function useCachedData<T>({
               timestamp: Date.now(),
               dependencies: dependencies
             };
-            cacheRef.current.set(cacheKey, newEntry);
+            globalCache.set(cacheKey, newEntry);
             if (usePersistentCache) {
               setStoredCache(cacheKey, newEntry);
             }
@@ -114,7 +119,7 @@ export function useCachedData<T>({
           timestamp: now,
           dependencies: [...dependencies] // Store current dependencies
         };
-        cacheRef.current.set(cacheKey, newEntry);
+        globalCache.set(cacheKey, newEntry);
         if (usePersistentCache) {
           setStoredCache(cacheKey, newEntry);
         }
@@ -131,7 +136,7 @@ export function useCachedData<T>({
 
   // Function to manually clear cache
   const clearCache = () => {
-    cacheRef.current.delete(cacheKey);
+    globalCache.delete(cacheKey);
     if (usePersistentCache) {
       clearStoredCache(cacheKey);
     }
@@ -139,7 +144,7 @@ export function useCachedData<T>({
 
   // Function to force refresh
   const refresh = () => {
-    cacheRef.current.delete(cacheKey);
+    globalCache.delete(cacheKey);
     if (usePersistentCache) {
       clearStoredCache(cacheKey);
     }
@@ -152,7 +157,7 @@ export function useCachedData<T>({
           timestamp: now,
           dependencies: [...dependencies]
         };
-        cacheRef.current.set(cacheKey, newEntry);
+        globalCache.set(cacheKey, newEntry);
         if (usePersistentCache) {
           setStoredCache(cacheKey, newEntry);
         }

--- a/src/pages/dashboard/my-quizzes/index.tsx
+++ b/src/pages/dashboard/my-quizzes/index.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCachedFetch } from "@/hooks/useCachedFetch";
 import { useRouter } from "next/router";
 import { SignedIn, SignedOut, useUser } from "@clerk/nextjs";
 import Head from "next/head";
 import Link from "next/link";
-import { MoreVertical, Trash2 } from "lucide-react";
+import { MoreVertical, Trash2, RefreshCw, Loader2 } from "lucide-react";
 import { useUserPlanContext } from "@/contexts/UserPlanContext";
 import { useUserRole } from "@/hooks/useUserRole";
 import { canPerformAction } from "@/utils/rolePermissions";
@@ -58,8 +58,10 @@ export default function MyQuizzesPage() {
   const { user, isLoaded } = useUser();
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(true);
-  const [quizzes, setQuizzes] = useState<QuizSummary[]>([]);
+  const [quizzes, setQuizzes] = useState<QuizSummary[] | null>(null);
   const [fetchError, setFetchError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [isRefreshingQuizzes, setIsRefreshingQuizzes] = useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [quizToDelete, setQuizToDelete] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -180,9 +182,21 @@ export default function MyQuizzesPage() {
   useEffect(() => {
     if (quizzesData) {
       setQuizzes(quizzesData);
+      setLastUpdated(new Date());
     }
     setFetchError(quizzesError ? quizzesError.message : null);
   }, [quizzesData, quizzesError]);
+
+  const handleRefreshQuizzes = useCallback(async () => {
+    if (!companyInfo?.id) return;
+    try {
+      setIsRefreshingQuizzes(true);
+      await queryClient.invalidateQueries({ queryKey: ['quizzes', companyInfo.id] });
+      setLastUpdated(new Date());
+    } finally {
+      setIsRefreshingQuizzes(false);
+    }
+  }, [queryClient, companyInfo?.id]);
 
   const handleDeleteQuiz = async (quizId: string) => {
     if (!quizId) return;
@@ -247,9 +261,35 @@ export default function MyQuizzesPage() {
             <div className="flex-1 flex flex-col">
               <DashboardHeader />
               <main className="flex-1 p-6">
-                <div className="mb-6">
-                  <h1 className="text-2xl font-semibold">My Quizzes</h1>
-                  <p className="text-white/70">Browse your generated quizzes and open any to view full details.</p>
+                <div className="flex justify-between items-center mb-6 flex-wrap gap-3">
+                  <div>
+                    <h1 className="text-2xl font-semibold">My Quizzes</h1>
+                    <p className="text-white/70">Browse your generated quizzes and open any to view full details.</p>
+                  </div>
+                  <div className="flex items-center gap-4">
+                    {lastUpdated && (
+                      <div className="text-sm text-gray-400">
+                        Last updated: {lastUpdated.toLocaleString()}
+                      </div>
+                    )}
+                    <Button
+                      onClick={handleRefreshQuizzes}
+                      className="flex items-center gap-2 bg-gradient-to-r from-green-500 to-blue-500 text-white hover:brightness-110 transition-all duration-300 shadow-md hover:shadow-xl"
+                      disabled={isRefreshingQuizzes}
+                    >
+                      {isRefreshingQuizzes ? (
+                        <>
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                          <span>Refreshing...</span>
+                        </>
+                      ) : (
+                        <>
+                          <RefreshCw className="h-4 w-4" />
+                          <span>Refresh</span>
+                        </>
+                      )}
+                    </Button>
+                  </div>
                 </div>
                 {fetchError ? (
                   <div className="border border-red-500/40 text-red-300 rounded-lg p-4">


### PR DESCRIPTION
- Fix Dashboard Analytics always reloading on revisit: useCachedData's cache was scoped to a useRef (dies on component unmount), moved to a module-level Map so useUserRole (and anything else depending on it) survives navigation the same way the already-cached quiz-results query does
- Fix My Quizzes flashing "No quizzes to show yet" before real data loads: quizzes state was initialized to [] instead of null, so the intended loading branch (isFetchingQuizzes && !quizzes) could never be true; also add a Refresh button + "Last updated" label matching the Analytics page
- Add a shared AdminRefreshButton (same gradient/icon-swap design as the Dashboard's Refresh button) and use it on all 6 admin pages that have one; useAdminData now tracks lastUpdated centrally so every page gets it for free
- Add a shared AdminPagination component (100/page) to the Quizzes, Companies, and Results/Attempts lists, resetting to page 1 on filter/search change
- Fix the admin Quizzes table wrapping awkwardly: horizontal scroll instead of clipping, whitespace-nowrap + truncation on every cell
- Fix the admin Attempt detail page never highlighting a candidate's wrong pick in red: it read ans.answer, but the field actually stored by the real submission flow is user_answer, so the candidate's pick was always undefined and the red highlight (and "their pick" label) could never fire