### PR TITLE
fix: candidate name showing as duplicated email in analytics/exports

### DIFF
--- a/src/app/[companyId]/take/quiz/[quizId]/page.tsx
+++ b/src/app/[companyId]/take/quiz/[quizId]/page.tsx
@@ -67,6 +67,12 @@ type FormData = {
   quizKey: string;
 };
 
+// Guards against candidates typing their email into the "Full Name" field
+// (a plain text input with no format enforcement) — without this, analytics
+// ends up with the same email duplicated in both the Username and Email
+// columns, which reads as a data bug even though it's just what was typed.
+const EMAIL_LIKE_PATTERN = /\S+@\S+\.\S+/;
+
 function CameraPermissionModal({ onGranted, onDismiss }: { 
   onGranted: () => void; 
   onDismiss: () => void; 
@@ -335,6 +341,7 @@ export default function QuizPage({ params }: PageProps) {
   const [quizStarted, setQuizStarted] = useState<boolean>(false);
   const [verifying, setVerifying] = useState<boolean>(false);
   const [verificationError, setVerificationError] = useState<string>('');
+  const [nameError, setNameError] = useState<string>('');
   const [warnings, setWarnings] = useState<number>(0);
   const [showWarning, setShowWarning] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -412,6 +419,7 @@ export default function QuizPage({ params }: PageProps) {
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
     setFormData(prev => ({ ...prev, [name]: value }));
+    if (name === 'name' && nameError) setNameError('');
   };
 
   const checkUserAttempts = useCallback(async (showToast = true): Promise<boolean> => {
@@ -997,6 +1005,11 @@ const topicPerformance = calculateTopicWisePerformance();
     });
     return;
   }
+  if (EMAIL_LIKE_PATTERN.test(formData.name.trim())) {
+    setNameError('That looks like an email address — please enter your full name instead.');
+    return;
+  }
+  setNameError('');
   await verifyQuizKey();
 };
 
@@ -1355,8 +1368,15 @@ const beginQuiz = useCallback(async () => {
                   <Input
                     id="name" name="name" value={formData.name} onChange={handleInputChange}
                     placeholder="Enter your Full Name" required
-                    className="h-12 bg-white/5 border-white/10 text-white placeholder-gray-400/60 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all duration-200"
+                    className={`h-12 bg-white/5 border-white/10 text-white placeholder-gray-400/60 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 transition-all duration-200 ${nameError ? 'border-red-500/50' : ''}`}
                   />
+                  {nameError && (
+                    <div className="bg-red-500/10 border border-red-500/20 rounded-lg p-3 mt-2">
+                      <p className="text-sm text-red-400 flex items-center gap-2">
+                        <AlertCircle className="h-4 w-4" /> {nameError}
+                      </p>
+                    </div>
+                  )}
                 </div>
 
                 <div className="space-y-2">

--- a/src/app/api/quiz_result/route.ts
+++ b/src/app/api/quiz_result/route.ts
@@ -146,7 +146,7 @@ export async function POST(request: NextRequest) {
 
     if (missingFields.length > 0) {
       return NextResponse.json(
-        { 
+        {
           detail: `Missing required fields: ${missingFields.join(', ')}`,
           received_data: {
             quiz_id: !!quiz_id,
@@ -157,6 +157,19 @@ export async function POST(request: NextRequest) {
             has_attempt: attempt !== undefined
           }
         },
+        { status: 400 }
+      );
+    }
+
+    // Defense-in-depth against the same issue the take-quiz form's client-side
+    // check guards against: a plain text "Full Name" field with no format
+    // enforcement lets a candidate type their email address as their name,
+    // which then shows up duplicated in both the Username and Email columns
+    // on the analytics page. Reject it server-side too in case that client
+    // check is ever bypassed (a direct API call, an older cached client, etc).
+    if (/\S+@\S+\.\S+/.test(String(username).trim())) {
+      return NextResponse.json(
+        { detail: 'username looks like an email address — please provide a full name instead' },
         { status: 400 }
       );
     }

--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -108,9 +108,21 @@ const formatDate = (dateString: string) =>
     day: "numeric",
   });
 
+// The quiz-taking form's "Full Name" field is plain text with no format
+// enforcement — a candidate can (and sometimes does) type their email
+// address into it. When that happens, showing the raw duplicate in the
+// Username column reads like a data/column-mapping bug even though it's
+// exactly what was submitted, so display a clear placeholder instead
+// (here and in the exports, which pull from the same field).
+const looksLikeEmail = (value: string) => /\S+@\S+\.\S+/.test(value.trim());
+const getDisplayName = (c: QuizResult) => {
+  const name = c.username?.trim();
+  return name && !looksLikeEmail(name) ? name : null;
+};
+
 const prepareExportData = (data: QuizResult[]) =>
   data.map((q) => ({
-    Username: q.username,
+    Username: getDisplayName(q) ?? "Name not provided",
     Email: q.user_email,
     Score: q.result.score,
     "Total Questions": q.result.total_questions ?? q.total_questions ?? 0,
@@ -755,7 +767,7 @@ export default function ResultsDashboard() {
                                                     key={i}
                                                     className="flex justify-between text-sm bg-zinc-800/60 p-2 rounded"
                                                   >
-                                                    <span className="truncate max-w-[140px]">{c.username}</span>
+                                                    <span className="truncate max-w-[140px]">{getDisplayName(c) ?? "Name not provided"}</span>
                                                     <span className="font-bold text-purple-300">
                                                       {c.result.score.toFixed(1)}%
                                                     </span>
@@ -985,7 +997,7 @@ export default function ResultsDashboard() {
                                               >
                                                 <Link href={`/${finalCompanyId}/analytics/candidate/${encodeURIComponent(c.user_email)}`}
                                                 target="_blank"
-                                                rel="noopener noreferrer" className="absolute inset-0 z-20" aria-label={`View ${c.username}'s analytics`}/>
+                                                rel="noopener noreferrer" className="absolute inset-0 z-20" aria-label={`View ${getDisplayName(c) ?? c.user_email}'s analytics`}/>
                                                 <TableCell className="relative z-30">
                                                   <input
                                                     type="checkbox"
@@ -994,7 +1006,9 @@ export default function ResultsDashboard() {
                                                     className="rounded border-zinc-600 text-purple-500 focus:ring-purple-500 bg-zinc-800 relative z-40"
                                                   />
                                                 </TableCell>
-                                                <TableCell className="font-medium relative z-10">{c.username}</TableCell>
+                                                <TableCell className="font-medium relative z-10">
+                                                  {getDisplayName(c) ?? <span className="italic text-zinc-500">Name not provided</span>}
+                                                </TableCell>
                                                 <TableCell className="hidden md:table-cell truncate max-w-xs relative z-10">
                                                   {c.user_email}
                                                 </TableCell>


### PR DESCRIPTION
Traced the full pipeline (quiz-taking form -> /api/quiz_result -> Python backend -> DB -> back to analytics) and confirmed there's no column-mapping bug anywhere - username/user_email are passed through verbatim at every layer. The "Full Name" field on the take-quiz page is a plain text input with no format enforcement, so a candidate can type their email address into it, which then shows up duplicated in both the Username and Email columns and reads like a bug.

- Validate against this going forward: reject an email-shaped value in the Full Name field client-side (inline error, matching the existing verificationError pattern) and server-side in /api/quiz_result's POST handler as defense-in-depth
- Display fix for already-affected rows: when username is empty or email-shaped, show "Name not provided" instead of the raw duplicate, consistently across the candidate table, the chart tooltip, the aria-label, and the Excel/PDF exports (all of which pull from the same field, so all showed the same confusing value)