### PR TITLE
fix: Edit Details button color and disabled Save Changes logic

### DIFF
--- a/src/components/Quiz/EditQuizDetailsModal.tsx
+++ b/src/components/Quiz/EditQuizDetailsModal.tsx
@@ -59,6 +59,11 @@ export function EditQuizDetailsModal({
     }
   }, [isOpen, initialSecretKey, initialMaxAttempts, initialExpirationDate]);
 
+  const hasChanges =
+    secretKey.trim() !== (initialSecretKey || "").trim() ||
+    Number(maxAttempts) !== Number(initialMaxAttempts || 1) ||
+    expirationDate !== toDateTimeLocalValue(initialExpirationDate);
+
   const handleSave = async () => {
     if (!companyId) {
       setError("Missing company information. Please refresh and try again.");
@@ -192,8 +197,8 @@ export function EditQuizDetailsModal({
           <Button
             type="button"
             onClick={handleSave}
-            disabled={isSaving}
-            className="w-full bg-blue-600 hover:bg-blue-700 text-white"
+            disabled={isSaving || !hasChanges}
+            className="w-full bg-blue-600 hover:bg-blue-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isSaving ? (
               <>

--- a/src/components/Quiz/QuizHeader.tsx
+++ b/src/components/Quiz/QuizHeader.tsx
@@ -172,8 +172,7 @@ export function QuizHeader({
           )}
           {isPublished && !roleLoading && canPerformAction(userRole, 'edit_publish_settings') && (
             <Button
-              variant="outline"
-              className="border-blue-500/40 text-blue-300 hover:bg-blue-500/10 hover:text-blue-200 pointer-events-auto transition-all duration-150 active:scale-95"
+              className="bg-blue-600 hover:bg-blue-700 text-white pointer-events-auto transition-all duration-150 active:scale-95"
               onClick={() => setIsEditDetailsModalOpen(true)}
               disabled={disableActions}
             >


### PR DESCRIPTION
Match the Edit Details button to the solid blue used elsewhere (e.g. Publish Quiz) instead of the outline style. Save Changes was only disabled while saving, so it was clickable even with no edits made; now it stays disabled until secret key, max attempts, or expiration actually differs from what was loaded.