### PR TITLE
fix: OAuth sign-in-with-no-account was silently becoming a sign-up

### DIFF
--- a/src/pages/sso-callback.tsx
+++ b/src/pages/sso-callback.tsx
@@ -30,11 +30,9 @@ export default function SSOCallback() {
     sessionStorage.removeItem("signupAttemptTime");
 
     const noAccountFound = () =>
-      clerk.client?.signIn?.firstFactorVerification?.status === "transferable" ||
       clerk.client?.signIn?.firstFactorVerification?.error?.code === "external_account_not_found";
 
     const accountAlreadyExists = () =>
-      clerk.client?.signUp?.verifications?.externalAccount?.status === "transferable" ||
       clerk.client?.signUp?.verifications?.externalAccount?.error?.code === "external_account_exists";
 
     const decideDestination = (fallback: string) => {
@@ -53,6 +51,17 @@ export default function SSOCallback() {
     clerk
       .handleRedirectCallback(
         {
+          // Clerk's default (transferable: true) auto-transfers a failed
+          // sign-in into a brand-new, incomplete sign-up behind the scenes
+          // ("prevents opaque sign ups" is literally the opposite of what
+          // we want here) — that's what the Clerk dashboard logs showed:
+          // oauth_callback.failed (reason external_account_not_found)
+          // followed immediately by sign_up.external_account.connected,
+          // even though the user only ever tried to sign IN. With transfer
+          // off, a sign-in with no matching account just fails cleanly, so
+          // our own noAccountFound()/catch logic below can actually decide
+          // to send the user to /signup instead of Clerk silently doing it.
+          transferable: false,
           signInFallbackRedirectUrl: "/dashboard",
           signUpFallbackRedirectUrl: "/onboarding",
         },


### PR DESCRIPTION
Your Clerk dashboard logs made this one unambiguous: every failed attempt showed oauth_callback.failed (reason
external_account_not_found) immediately followed by sign_up.external_account.connected — even though the user only ever tried to sign IN. Clerk's handleRedirectCallback defaults transferable to true, and its own doc string says exactly what it does: "prevents opaque sign ups when a user attempts to sign in via OAuth with an email that doesn't exist" — i.e. the default is to allow it. So instead of failing cleanly with a code our redirect logic could catch, Clerk was auto-creating a brand-new, incomplete sign-up behind the scenes every time, which is why neither of the previous two fixes ever had anything to detect.

Set transferable: false so a sign-in with no matching Google account now fails as a plain, catchable error instead of silently opening an opaque sign-up.