### PR TITLE
fix: mark /sso-callback as a public route in middleware

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,6 +21,11 @@ const isPublicRoute = createRouteMatcher([
   '/accept_invite',      // Public route for invites
   '/signin',            // Public route - let components handle auth flow
   '/signup',            // Public route - let components handle auth flow
+  '/sso-callback',      // Public route - OAuth callback page. A sign-in attempt with no
+                         // matching account never gets a session (there's nothing to sign
+                         // into), so without this, middleware's own !userId check redirected
+                         // to /signin server-side before this page's client-side redirect
+                         // logic ever ran — no client-side fix here could ever have worked.
   '/admin(.*)',         // Internal admin panel — gated by its own env-credential session, not Clerk
 ]);
 


### PR DESCRIPTION
An OAuth sign-in attempt with no matching account never gets a session (there's nothing to sign into), so when the browser lands on /sso-callback, middleware's own !userId check fired first and redirected to /signin server-side, before the page's client-side redirect logic (which decides to send the user to /signup instead) ever had a chance to run. This is why the prior client-side-only fix to sso-callback.tsx/useSignInController.ts had no visible effect: the request never reached that code for this specific scenario. Successful sign-ins were unaffected since Clerk creates the session before ever redirecting here, so userId is already populated by the time middleware checks.