### PR TITLE
Enable Delete Quiz Data for Admin, allow Member for own quizzes; hide…

### DIFF
--- a/src/pages/dashboard/analytics/index.tsx
+++ b/src/pages/dashboard/analytics/index.tsx
@@ -490,6 +490,22 @@ export default function ResultsDashboard() {
     return map;
   }, [publishedQuizzesData]);
 
+  // Needed so a Member can delete analytics data for quizzes they personally
+  // generated, mirroring the isQuizOwner check already used for delete_quiz
+  // on the My Quizzes page — quiz_result data alone has no creator field.
+  const { data: companyQuizzesData } = useCachedFetch<{ quiz_id: string; user_id?: string }[]>(
+    ['companyQuizzes', finalCompanyId as string],
+    finalCompanyId ? `/api/quizzes?companyId=${encodeURIComponent(finalCompanyId)}` : '',
+    { enabled: Boolean(finalCompanyId) }
+  );
+  const creatorByQuizId = useMemo(() => {
+    const map = new Map<string, string>();
+    (Array.isArray(companyQuizzesData) ? companyQuizzesData : []).forEach((q) => {
+      if (q.user_id) map.set(q.quiz_id, q.user_id);
+    });
+    return map;
+  }, [companyQuizzesData]);
+
   useEffect(() => {
     if (quizResults) {
       setLastUpdated(new Date());
@@ -815,7 +831,9 @@ export default function ResultsDashboard() {
                                 </div>
                               </div>
 
-                              {effectiveRole && canPerformAction(effectiveRole, 'delete_analytics_all') ? (
+                              {effectiveRole && canPerformAction(effectiveRole, 'delete_analytics_all', {
+                                isQuizOwner: creatorByQuizId.get(quiz.quiz_id) === user?.id,
+                              }) ? (
                                 <Button
                                   variant="destructive"
                                   onClick={() =>

--- a/src/pages/dashboard/teams/index.tsx
+++ b/src/pages/dashboard/teams/index.tsx
@@ -132,12 +132,14 @@ function MemberCard({
   onDelete,
   userRole,
   dataLoading,
+  isSelf,
 }: {
   member: CompanyMember;
   onEditRole: (m: CompanyMember) => void;
   onDelete: (id: string, name: string) => void;
   userRole: UserRole | null;
   dataLoading: boolean;
+  isSelf: boolean;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -177,7 +179,11 @@ function MemberCard({
           </div>
 
           <div className="relative flex-shrink-0" ref={menuRef}>
-            {!dataLoading && canPerformAction(userRole, "manage_roles") && (
+            {/* An Owner can't change their own role directly — that only
+                happens as a side effect of making someone else the Owner
+                (see the transfer-ownership confirmation flow), so their own
+                card gets no actions menu at all. */}
+            {!dataLoading && !(isSelf && member.role === "OWNER") && canPerformAction(userRole, "manage_roles") && (
               <button
                 onClick={() => setMenuOpen((o) => !o)}
                 className={`h-[28px] w-[28px] rounded-[8px] border flex flex-col items-center justify-center gap-[2.5px] transition-all duration-100 ${
@@ -1061,6 +1067,7 @@ export default function TeamsPage() {
                           onDelete={promptDeleteMember}
                           userRole={userRole}
                           dataLoading={dataLoading}
+                          isSelf={member.user_id === user?.id}
                         />
                       ))}
                     </div>

--- a/src/utils/rolePermissions.ts
+++ b/src/utils/rolePermissions.ts
@@ -53,7 +53,7 @@ const PERMISSION_MATRIX: PermissionMatrix = {
     delete_quiz: true,
     edit_publish_settings: true,
     view_analytics: true,
-    delete_analytics_all: false,
+    delete_analytics_all: true,
     delete_analytics_specific: true, // Admin can delete specific records
     invite_members: true,
     manage_roles: false,
@@ -114,6 +114,14 @@ export const canPerformAction = (
   // as publishing itself (mirrors the backend check in quiz_generation).
   if (permission === 'delete_quiz' && userRole.role === 'MEMBER') {
     return Boolean(additionalContext?.isQuizOwner) && !additionalContext?.isPublished;
+  }
+
+  // A Member may clear analytics/attempt data for a quiz they personally
+  // generated, regardless of publish state — this only removes result
+  // history, it doesn't touch the quiz record or its publish status, so it
+  // doesn't need the same unpublished-only restriction as delete_quiz.
+  if (permission === 'delete_analytics_all' && userRole.role === 'MEMBER') {
+    return Boolean(additionalContext?.isQuizOwner);
   }
 
   return hasPermission(userRole.role, permission);


### PR DESCRIPTION
- delete_analytics_all: enabled for Admin unconditionally, and for Member scoped to quizzes they personally generated (mirrors the delete_quiz own-unpublished-quiz rule already used elsewhere).
- Teams page: the Owner's own card no longer shows the three-dot actions menu, since an Owner can't change their own role directly — that only happens as a side effect of transferring ownership to someone else.