### PR TITLE
Add document-flow and proctoring FAQs, fix speed claim, broaden copy …

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,11 +20,11 @@ export const viewport: Viewport = {
 export const metadata: Metadata = {
   metadataBase: new URL(siteUrl),
   title: {
-    default: "QuizzViz – Skip Resumes And Interview The Best Devs",
+    default: "QuizzViz – Turn Any Document Into a Secure Assessment with AI",
     template: "%s | QuizzViz",
   },
   description:
-    "QuizzViz helps companies create high-quality, real-world coding quizzes in minutes. Fast, reliable, and built for professionals.",
+    "QuizzViz turns your documents, or a tech stack, into AI-generated hiring assessments for any role, technical or non-technical. Secure, reliable, and built for enterprise hiring teams.",
   applicationName: "QuizzViz",
   generator: "Next.js",
   keywords: [
@@ -57,9 +57,10 @@ export const metadata: Metadata = {
     icon: "/favicon.ico",
   },
   openGraph: {
-    title: "QuizzViz – Skip Resumes And Interview The Best Devs  "   ,     
+    title: "QuizzViz – Turn Any Document Into a Secure Assessment with AI",
     description:
-"QuizzViz helps companies skip resumes and interview the best devs",    url: siteUrl,
+      "QuizzViz turns your documents, or a tech stack, into AI-generated hiring assessments for any role, technical or non-technical.",
+    url: siteUrl,
     siteName: "QuizzViz",
     images: [
       {
@@ -74,9 +75,10 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "QuizzViz – Skip Resumes And Interview The Best Devs",
+    title: "QuizzViz – Turn Any Document Into a Secure Assessment with AI",
     description:
-"QuizzViz helps companies skip resumes and interview the best devs",    images: [`${siteUrl}/QuizzViz-logo.png`],
+      "QuizzViz turns your documents, or a tech stack, into AI-generated hiring assessments for any role, technical or non-technical.",
+    images: [`${siteUrl}/QuizzViz-logo.png`],
     creator: "@QuizzViz",
     site: "@QuizzViz",
   },
@@ -113,7 +115,7 @@ export const metadata: Metadata = {
         logo: `${siteUrl}/QuizzViz-logo.png`,
         image: `${siteUrl}/QuizzViz-logo.png`,
         description:
-          "QuizzViz helps companies skip resumes and interview the best devs",
+          "QuizzViz turns documents, or a tech stack, into AI-generated hiring assessments for any role, technical or non-technical.",
         sameAs: [
           "https://www.linkedin.com/company/quizzviz",
           "https://x.com/QuizzViz",

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -18,7 +18,7 @@ export function Footer() {
               </span>
             </Link>
             <p className="text-sm leading-relaxed text-muted-foreground max-w-sm">
-              We empower teams to streamline their technical hiring process
+              We empower teams to streamline hiring for any role, technical or non-technical
             </p>
           </div>
 

--- a/src/pages/landingPage/parts/CTASection.tsx
+++ b/src/pages/landingPage/parts/CTASection.tsx
@@ -20,7 +20,7 @@ const CTASection: FC = () => {
             Ready to Transform Your <span className="gradient-text font-medium">Hiring Process?</span>
           </h2>
           <p className="text-lg lg:text-xl text-muted-foreground mb-12 max-w-3xl mx-auto leading-relaxed opacity-90">
-            Join leading companies using QuizzViz to streamline technical hiring, reduce time-to-hire, and identify top talent with AI-powered coding assessments.
+            Join leading companies using QuizzViz to streamline hiring for any role, reduce time-to-hire, and identify top talent with AI-powered assessments generated from documents or a tech stack.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Link href="/pricing">

--- a/src/pages/landingPage/parts/FAQsSection.tsx
+++ b/src/pages/landingPage/parts/FAQsSection.tsx
@@ -41,20 +41,43 @@ const FAQsSection: FC = () => (
             <h3 className="text-xl font-semibold text-foreground tracking-tight">What is QuizzViz ?</h3>
           </AccordionTrigger>
           <AccordionContent className="px-6 py-4 text-sm text-muted-foreground leading-relaxed opacity-90">
-            QuizzViz is a pre-screening technical assessment platform that turns your own documents, or a tech stack, into AI-generated coding quizzes. By automatically filtering out unqualified candidates, it saves valuable interview time by ensuring only the most competent candidates progress to the interview stage. It's designed specifically for hiring teams to assess technical skills quickly and effectively.
+            QuizzViz is a pre-screening assessment platform that turns your own documents, or a tech stack, into AI-generated quizzes for any role, technical or non-technical. By automatically filtering out unqualified candidates, it saves valuable interview time by ensuring only the most competent candidates progress to the interview stage. It's designed specifically for hiring teams to assess candidate skills quickly and effectively.
           </AccordionContent>
         </AccordionItem>
-        
+
         <AccordionItem value="item-2" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
+          <AccordionTrigger className="px-6 py-4 text-left hover:no-underline focus:no-underline">
+            <h3 className="text-xl font-semibold text-foreground tracking-tight">How does document-based quiz generation work?</h3>
+          </AccordionTrigger>
+          <AccordionContent className="px-6 py-4 text-sm text-muted-foreground leading-relaxed opacity-90">
+            Upload a document relevant to the role, such as a job description, training manual, policy document, or technical specification, and QuizzViz's AI reads its content and drafts role-specific questions directly from it. Set the experience level and number of questions, review and adjust anything you'd like, then publish and share the assessment exactly like any other quiz.
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="item-3" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
+          <AccordionTrigger className="px-6 py-4 text-left hover:no-underline focus:no-underline">
+            <h3 className="text-xl font-semibold text-foreground tracking-tight">Can I generate a quiz for any role, not just technical ones?</h3>
+          </AccordionTrigger>
+          <AccordionContent className="px-6 py-4 text-sm text-muted-foreground leading-relaxed opacity-90">
+            Yes. QuizzViz isn't limited to coding roles. Upload a document for any position, including Sales, Marketing, HR, Finance, or Operations, and the AI generates a quiz tailored to it. For technical roles, a tech stack works just as well as a document, whichever fits the role best.
+          </AccordionContent>
+        </AccordionItem>
+
+        <AccordionItem value="item-4" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
           <AccordionTrigger className="px-6 py-4 text-left hover:no-underline focus:no-underline">
             <h3 className="text-xl font-semibold text-foreground tracking-tight">How does proctoring work?</h3>
           </AccordionTrigger>
           <AccordionContent className="px-6 py-4 text-sm text-muted-foreground leading-relaxed opacity-90">
-            Our proctoring system automatically terminates the quiz if the candidate switches tabs or windows during the assessment. This ensures test integrity by preventing candidates from looking up answers.
+            Every assessment runs in full-screen with the candidate's camera active throughout, and QuizzViz responds differently depending on what it detects:
+            <ul className="list-disc pl-5 mt-2 space-y-1">
+              <li>Attention and presence: if the candidate looks left, right, or down, their face is no longer detected, or a mobile phone appears in frame, a 20-second warning appears. If it isn't corrected in time, the quiz terminates automatically.</li>
+              <li>Tab or window switching: leaving the quiz tab or window ends the assessment immediately, with no warning period.</li>
+              <li>Exiting full-screen: minimizing or leaving full-screen prompts the candidate to continue or end the quiz. Choosing to continue restores full-screen mode automatically; choosing to end submits the attempt.</li>
+            </ul>
           </AccordionContent>
         </AccordionItem>
-        
-        <AccordionItem value="item-3" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
+
+        <AccordionItem value="item-5" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
           <AccordionTrigger className="px-6 py-4 text-left hover:no-underline focus:no-underline">
             <h3 className="text-xl font-semibold text-foreground tracking-tight">How do I share a quiz with candidates?</h3>
           </AccordionTrigger>
@@ -62,8 +85,8 @@ const FAQsSection: FC = () => (
             Simply generate a shareable link and a secret key for your quiz. Share both with candidates, who can then access and attempt the assessment.
           </AccordionContent>
         </AccordionItem>
-        
-        <AccordionItem value="item-4" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
+
+        <AccordionItem value="item-6" className="rounded-2xl border-0 bg-white/5 backdrop-blur-xl border-white/10">
           <AccordionTrigger className="px-6 py-4 text-left hover:no-underline focus:no-underline">
             <h3 className="text-xl font-semibold text-foreground tracking-tight">What analytics are available?</h3>
           </AccordionTrigger>

--- a/src/pages/landingPage/parts/FeaturesSection.tsx
+++ b/src/pages/landingPage/parts/FeaturesSection.tsx
@@ -30,7 +30,7 @@ const FeaturesSection: FC = () => {
     {
       icon: Zap,
       title: "Enterprise-Grade Assessments",
-      description: "Turn your own documents, or your company's tech stack, into customized coding tests tailored to each role. Our AI-powered platform generates relevant challenges in minutes, saving your hiring team countless hours.",
+      description: "Turn your own documents, or your company's tech stack, into customized assessments tailored to any role, technical or non-technical. Our AI-powered platform generates relevant questions in minutes, saving your hiring team countless hours.",
       gradient: "from-green-500/80 to-blue-500/80",
       ring: "ring-green-500/30"
     },
@@ -67,7 +67,7 @@ const FeaturesSection: FC = () => {
               </span>
             </h2>
             <p className="text-lg lg:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-              Designed exclusively for companies to identify top technical talent efficiently and securely. Scale your hiring without compromising on quality or security.
+              Designed exclusively for companies to identify top talent for any role, efficiently and securely. Scale your hiring without compromising on quality or security.
             </p>
           </div>
         </div>

--- a/src/pages/landingPage/parts/HeroSection.tsx
+++ b/src/pages/landingPage/parts/HeroSection.tsx
@@ -13,7 +13,7 @@ const trustPills = [
 
 const pipelineSteps = [
   { icon: FileText, title: "Upload a Document", description: "Or generate from a tech stack instead." },
-  { icon: Sparkles, title: "AI Builds the Assessment", description: "Role-specific questions, ready in seconds." },
+  { icon: Sparkles, title: "AI Builds the Assessment", description: "Role-specific questions, ready in minutes." },
   { icon: ShieldCheck, title: "Evaluate Securely", description: "A protected link and key for every candidate." },
   { icon: BarChart3, title: "Decide with Confidence", description: "Compare candidates with actionable insights." },
 ];

--- a/src/pages/landingPage/parts/HowItWorksSection.tsx
+++ b/src/pages/landingPage/parts/HowItWorksSection.tsx
@@ -64,7 +64,7 @@ const HowItWorksSection: FC = () => {
               </span>
             </h2>
             <p className="text-lg lg:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed">
-              Three simple steps to find and hire the best technical talent efficiently and effectively.
+              Three simple steps to find and hire the best talent for any role, efficiently and effectively.
             </p>
           </div>
         </div>

--- a/src/pages/landingPage/parts/ProblemsSection.tsx
+++ b/src/pages/landingPage/parts/ProblemsSection.tsx
@@ -40,7 +40,7 @@ const ProblemsSection: FC = () => {
               </span>
             </h2>
             <p className="text-lg lg:text-xl text-muted-foreground max-w-3xl mx-auto leading-relaxed opacity-90">
-              Our AI-powered platform helps you identify top technical talent efficiently with automated coding assessments, proctored evaluations, and detailed analytics to make data-driven hiring decisions.
+              Our AI-powered platform helps you identify top talent for any role, generating assessments from your documents or a tech stack, with proctored evaluations and detailed analytics to make data-driven hiring decisions.
             </p>
           </div>
         </div>

--- a/src/pages/mission/index.js
+++ b/src/pages/mission/index.js
@@ -18,7 +18,7 @@ export default function OurMission() {
     <>
       <Head>
         <title>Mission | QuizzViz</title>
-        <meta name="description" content="A better way to assess technical skills" />
+        <meta name="description" content="A better way to assess candidate skills, technical or non-technical" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
       
@@ -30,7 +30,7 @@ export default function OurMission() {
                 Smarter <span className="text-teal-400">Hiring</span>
               </h1>
               <p className="text-xl text-gray-400 leading-relaxed">
-                We help companies find the right technical talent through AI-generated, skill-based assessments built from your own documents, or from any tech stack
+                We help companies find the right talent, technical or non-technical, through AI-generated, skill-based assessments built from your own documents, or from any tech stack
               </p>
             </div>
           </div>
@@ -39,7 +39,7 @@ export default function OurMission() {
             <div className="bg-gray-900/50 rounded-2xl p-8 space-y-6 border border-gray-800/50">
               <h3 className="text-2xl font-semibold text-teal-400">Our Approach</h3>
               <p className="text-gray-300 leading-relaxed">
-                Traditional hiring often focuses too much on resumes and not enough on actual skills. We believe in assessing technical abilities first, before the interview stage, whether that means turning your own documents into a role-specific assessment with AI or generating a quiz from a tech stack.
+                Traditional hiring often focuses too much on resumes and not enough on actual skills. We believe in assessing candidate abilities first, before the interview stage, whether the role is technical or non-technical. Turn your own documents into a role-specific assessment with AI, or generate one from a tech stack for technical roles, whichever fits best.
               </p>
               
               <div className="space-y-4 mt-6">
@@ -51,7 +51,7 @@ export default function OurMission() {
                   </div>
                   <div>
                     <h4 className="font-medium text-gray-100">Skills First</h4>
-                    <p className="text-gray-400 text-sm">Assess technical abilities before scheduling interviews</p>
+                    <p className="text-gray-400 text-sm">Assess candidate abilities before scheduling interviews</p>
                   </div>
                 </div>
                 
@@ -63,7 +63,7 @@ export default function OurMission() {
                   </div>
                   <div>
                     <h4 className="font-medium text-gray-100">Save Time</h4>
-                    <p className="text-gray-400 text-sm">Focus on qualified candidates who meet your technical bar</p>
+                    <p className="text-gray-400 text-sm">Focus on qualified candidates who meet the bar for the role</p>
                   </div>
                 </div>
                 


### PR DESCRIPTION

Adds two FAQs: how document-based quiz generation works, and confirming any role (not just technical) can be generated from a document. Rewrites the proctoring FAQ to precisely match the actual implementation -- full-screen plus camera throughout, a 20-second warning for gaze/face/phone violations, instant termination on tab switch, and a continue-or-end prompt on exiting full-screen.

Corrects the Hero's "ready in seconds" claim to "ready in minutes", matching real generation time.

Sweeps homepage copy, site-wide metadata (title/description/OG/ Twitter/JSON-LD in layout.tsx), and the footer to stop implying QuizzViz is coding/developer-only -- it generates assessments for any role from a document. Also rebalances the Mission page so technical and non-technical hiring are presented as equal paths rather than technical being the default framing.